### PR TITLE
fix: resolve 404 error on project detail page due to OAuth user ID mismatch

### DIFF
--- a/fullstack-agent/lib/auth.ts
+++ b/fullstack-agent/lib/auth.ts
@@ -101,20 +101,18 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       }
       return token;
     },
-    async session({ session, token }) {
-      if (session.user) {
-        if (token.id) {
-          session.user.id = token.id as string;
-        }
-
-        // Get the actual user from database
+    async session({ session }) {
+      if (session.user && session.user.email) {
+        // Always lookup user by email to get the correct database ID
         const dbUser = await prisma.user.findUnique({
           where: {
-            id: session.user.id
+            email: session.user.email
           }
         });
 
         if (dbUser) {
+          // Set the correct database ID
+          session.user.id = dbUser.id;
           session.user.githubToken = dbUser.githubToken || undefined;
         }
       }


### PR DESCRIPTION
Fixed issue where session.user.id contained OAuth provider ID instead of database cuid, causing project detail pages to return 404. #13 

Updated session callback to always query user by email and set the correct database ID, ensuring consistent user identification across all pages.

Solution

Updated lib/auth.ts session callback to always query user by email and set session.user.id to the database cuid:

```js
async session({ session }) {
  if (session.user && session.user.email) {
    const dbUser = await prisma.user.findUnique({
      where: { email: session.user.email }
    });

    if (dbUser) {
      session.user.id = dbUser.id;  // Use database cuid
    }
  }
  return session;
}
```