### PR TITLE
chore: Bump runtime to v0.0.1-alpha.10 and update environment configuration

### DIFF
--- a/.github/workflows/build-runtime-manual.yml
+++ b/.github/workflows/build-runtime-manual.yml
@@ -1,4 +1,4 @@
-name: Manual Build Runtime v0.0.1-alpha.9
+name: Manual Build Runtime v0.0.1-alpha.10
 
 on:
   workflow_dispatch:
@@ -11,7 +11,7 @@ on:
 env:
   DOCKER_REGISTRY: docker.io
   IMAGE_NAME: fullstackagent/fullstack-web-runtime
-  IMAGE_TAG: v0.0.1-alpha.9
+  IMAGE_TAG: v0.0.1-alpha.10
 
 jobs:
   build-and-push:
@@ -43,7 +43,7 @@ jobs:
           push: true
           tags: |
             ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
-            ${{ env.IMAGE_NAME }}:0.0.1-alpha.9
+            ${{ env.IMAGE_NAME }}:0.0.1-alpha.10
             ${{ env.IMAGE_NAME }}:0.0.1
             ${{ env.IMAGE_NAME }}:latest
           labels: |
@@ -61,7 +61,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Image Tags:**" >> $GITHUB_STEP_SUMMARY
           echo "- \`${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- \`${{ env.IMAGE_NAME }}:0.0.1-alpha.9\`" >> $GITHUB_STEP_SUMMARY
+          echo "- \`${{ env.IMAGE_NAME }}:0.0.1-alpha.10\`" >> $GITHUB_STEP_SUMMARY
           echo "- \`${{ env.IMAGE_NAME }}:latest\`" >> $GITHUB_STEP_SUMMARY
           echo "- \`${{ env.IMAGE_NAME }}:0.0.1\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ secrets.yml
 next-env.d.ts
 
 /lib/generated/prisma
+/.idea

--- a/README.md
+++ b/README.md
@@ -156,7 +156,10 @@ Place your kubeconfig file in `.secret/kubeconfig`
 
 Create `.secret/.env` file with your Anthropic API credentials:
 ```env
-ANTHROPIC_API_KEY="your-anthropic-api-key"
+ANTHROPIC_AUTH_TOKEN="your-anthropic-api-key"
+ANTHROPIC_BASE_URL="your-anthropic-api-url"
+
+CLAUDE_AUTO_STARTED=0
 ```
 
 6. Initialize the database:


### PR DESCRIPTION
## Summary
- Bumped runtime image version from `v0.0.1-alpha.9` to `v0.0.1-alpha.10`
- Updated environment variable configuration for Claude Code CLI
- Applied code formatting to `kubernetes.ts`
- Added `.idea` to gitignore

## Changes

### Runtime Version
- Updated workflow file to build and tag `v0.0.1-alpha.10`

### Environment Variables (Breaking Change)
- Changed `ANTHROPIC_API_KEY` → `ANTHROPIC_AUTH_TOKEN`
- Added `ANTHROPIC_BASE_URL` for custom API endpoints
- Added `CLAUDE_AUTO_STARTED=0` flag

### Code Quality
- Applied Prettier formatting to `kubernetes.ts` (consistent semicolons, line breaks)
- Simplified kubeconfig loading (removed fallback to parent directory)

### Developer Experience
- Added `/.idea` to gitignore for IntelliJ IDEA users

## Test Plan
- [x] Verify runtime image builds successfully with new version tag
- [x] Test environment variable injection in sandbox containers
- [x] Confirm Claude Code CLI starts with new auth token format

🤖 Generated with [Claude Code](https://claude.com/claude-code)