### PR TITLE
chore: Bump runtime to v0.0.1-alpha.11 with pod security fixes

### DIFF
--- a/.github/workflows/build-runtime-manual.yml
+++ b/.github/workflows/build-runtime-manual.yml
@@ -1,4 +1,4 @@
-name: Manual Build Runtime v0.0.1-alpha.10
+name: Manual Build Runtime v0.0.1-alpha.11
 
 on:
   workflow_dispatch:
@@ -11,7 +11,7 @@ on:
 env:
   DOCKER_REGISTRY: docker.io
   IMAGE_NAME: fullstackagent/fullstack-web-runtime
-  IMAGE_TAG: v0.0.1-alpha.10
+  IMAGE_TAG: v0.0.1-alpha.11
 
 jobs:
   build-and-push:
@@ -43,7 +43,7 @@ jobs:
           push: true
           tags: |
             ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
-            ${{ env.IMAGE_NAME }}:0.0.1-alpha.10
+            ${{ env.IMAGE_NAME }}:0.0.1-alpha.11
             ${{ env.IMAGE_NAME }}:0.0.1
             ${{ env.IMAGE_NAME }}:latest
           labels: |

--- a/lib/kubernetes.ts
+++ b/lib/kubernetes.ts
@@ -1,82 +1,82 @@
-import * as k8s from '@kubernetes/client-node';
-import fs from 'fs';
-import path from 'path';
-import { VERSIONS, getRuntimeImage } from './config/versions';
+import * as k8s from '@kubernetes/client-node'
+import fs from 'fs'
+import path from 'path'
+import { VERSIONS, getRuntimeImage } from './config/versions'
 
 export class KubernetesService {
-  private kc: k8s.KubeConfig;
-  private k8sApi: k8s.CoreV1Api;
-  private k8sAppsApi: k8s.AppsV1Api;
-  private k8sNetworkingApi: k8s.NetworkingV1Api;
+  private kc: k8s.KubeConfig
+  private k8sApi: k8s.CoreV1Api
+  private k8sAppsApi: k8s.AppsV1Api
+  private k8sNetworkingApi: k8s.NetworkingV1Api
 
   constructor() {
-    this.kc = new k8s.KubeConfig();
+    this.kc = new k8s.KubeConfig()
 
     // Load kubeconfig from file - CRITICAL: Must use absolute path and verify loading
     // Check both current directory and parent directory for .secret/kubeconfig
-    const kubeconfigPath = path.join(process.cwd(), '.secret', 'kubeconfig');
-    console.log(`Loading kubeconfig from: ${kubeconfigPath}`);
+    const kubeconfigPath = path.join(process.cwd(), '.secret', 'kubeconfig')
+    console.log(`Loading kubeconfig from: ${kubeconfigPath}`)
 
     if (fs.existsSync(kubeconfigPath)) {
       try {
-        this.kc.loadFromFile(kubeconfigPath);
-        const cluster = this.kc.getCurrentCluster();
-        const context = this.kc.getCurrentContext();
-        const contextObj = this.kc.getContextObject(context);
-        console.log(`✅ Kubeconfig loaded successfully:`);
-        console.log(`  - Server: ${cluster?.server}`);
-        console.log(`  - Context: ${context}`);
-        console.log(`  - Namespace: ${contextObj?.namespace}`);
+        this.kc.loadFromFile(kubeconfigPath)
+        const cluster = this.kc.getCurrentCluster()
+        const context = this.kc.getCurrentContext()
+        const contextObj = this.kc.getContextObject(context)
+        console.log(`✅ Kubeconfig loaded successfully:`)
+        console.log(`  - Server: ${cluster?.server}`)
+        console.log(`  - Context: ${context}`)
+        console.log(`  - Namespace: ${contextObj?.namespace}`)
 
         // Verify we have the correct cluster endpoint
         if (!cluster?.server || cluster.server.includes('localhost')) {
-          throw new Error(`Invalid server endpoint: ${cluster?.server}`);
+          throw new Error(`Invalid server endpoint: ${cluster?.server}`)
         }
       } catch (error) {
-        console.error('❌ Failed to load kubeconfig:', error);
-        throw new Error(`Failed to load kubeconfig from ${kubeconfigPath}: ${error}`);
+        console.error('❌ Failed to load kubeconfig:', error)
+        throw new Error(`Failed to load kubeconfig from ${kubeconfigPath}: ${error}`)
       }
     } else {
-      console.error(`❌ Kubeconfig file not found at: ${kubeconfigPath}`);
-      throw new Error(`Kubeconfig file not found at: ${kubeconfigPath}`);
+      console.error(`❌ Kubeconfig file not found at: ${kubeconfigPath}`)
+      throw new Error(`Kubeconfig file not found at: ${kubeconfigPath}`)
     }
 
     // Configure TLS settings for HTTPS endpoints
-    const cluster = this.kc.getCurrentCluster();
+    const cluster = this.kc.getCurrentCluster()
     if (cluster && cluster.server && cluster.server.startsWith('https://')) {
       // For Sealos clusters, we trust the certificate
-      cluster.skipTLSVerify = false;
+      cluster.skipTLSVerify = false
     }
 
-    this.k8sApi = this.kc.makeApiClient(k8s.CoreV1Api);
-    this.k8sAppsApi = this.kc.makeApiClient(k8s.AppsV1Api);
-    this.k8sNetworkingApi = this.kc.makeApiClient(k8s.NetworkingV1Api);
+    this.k8sApi = this.kc.makeApiClient(k8s.CoreV1Api)
+    this.k8sAppsApi = this.kc.makeApiClient(k8s.AppsV1Api)
+    this.k8sNetworkingApi = this.kc.makeApiClient(k8s.NetworkingV1Api)
 
-    console.log('✅ Kubernetes API clients initialized');
+    console.log('✅ Kubernetes API clients initialized')
   }
 
   // Get the default namespace from kubeconfig
   getDefaultNamespace(): string {
-    const currentContextName = this.kc.getCurrentContext();
+    const currentContextName = this.kc.getCurrentContext()
     if (currentContextName) {
-      const contextObj = this.kc.getContextObject(currentContextName);
+      const contextObj = this.kc.getContextObject(currentContextName)
       if (contextObj && contextObj.namespace) {
-        return contextObj.namespace;
+        return contextObj.namespace
       }
     }
     // Fallback to the namespace from kubeconfig we know
-    return 'ns-ajno7yq7';
+    return 'ns-ajno7yq7'
   }
 
   async createPostgreSQLDatabase(projectName: string, namespace?: string) {
-    namespace = namespace || this.getDefaultNamespace();
-    const randomSuffix = this.generateRandomSuffix();
+    namespace = namespace || this.getDefaultNamespace()
+    const randomSuffix = this.generateRandomSuffix()
     // Convert project name to k8s-compatible format (lowercase, alphanumeric, hyphens)
     const k8sProjectName = projectName
       .toLowerCase()
       .replace(/[^a-z0-9-]/g, '')
-      .substring(0, 20);
-    const clusterName = `${k8sProjectName}-agentruntime-${randomSuffix}`;
+      .substring(0, 20)
+    const clusterName = `${k8sProjectName}-agentruntime-${randomSuffix}`
 
     // 1. Create ServiceAccount (from yaml/database/account.yaml)
     const serviceAccount = {
@@ -92,9 +92,9 @@ export class KubernetesService {
         name: clusterName,
         namespace,
       },
-    };
+    }
 
-    await this.k8sApi.createNamespacedServiceAccount({ namespace, body: serviceAccount as any });
+    await this.k8sApi.createNamespacedServiceAccount({ namespace, body: serviceAccount as any })
 
     // 2. Create Role
     const role = {
@@ -117,10 +117,10 @@ export class KubernetesService {
           verbs: ['*'],
         },
       ],
-    };
+    }
 
-    const rbacApi = this.kc.makeApiClient(k8s.RbacAuthorizationV1Api);
-    await rbacApi.createNamespacedRole({ namespace, body: role as any });
+    const rbacApi = this.kc.makeApiClient(k8s.RbacAuthorizationV1Api)
+    await rbacApi.createNamespacedRole({ namespace, body: role as any })
 
     // 3. Create RoleBinding
     const roleBinding = {
@@ -147,9 +147,9 @@ export class KubernetesService {
           name: clusterName,
         },
       ],
-    };
+    }
 
-    await rbacApi.createNamespacedRoleBinding({ namespace, body: roleBinding as any });
+    await rbacApi.createNamespacedRoleBinding({ namespace, body: roleBinding as any })
 
     // 4. Create KubeBlocks Cluster (from yaml/database/cluster.yaml)
     const cluster = {
@@ -207,32 +207,32 @@ export class KubernetesService {
         terminationPolicy: 'Delete',
         tolerations: [],
       },
-    };
+    }
 
     // Use custom resource API for KubeBlocks Cluster
-    const customObjectsApi = this.kc.makeApiClient(k8s.CustomObjectsApi);
+    const customObjectsApi = this.kc.makeApiClient(k8s.CustomObjectsApi)
     await customObjectsApi.createNamespacedCustomObject({
       group: 'apps.kubeblocks.io',
       version: 'v1alpha1',
       namespace: namespace,
       plural: 'clusters',
       body: cluster,
-    });
+    })
 
     // Wait for the cluster to be ready and get actual credentials
-    console.log(`⏳ Waiting for database cluster '${clusterName}' to be ready...`);
-    const isReady = await this.waitForDatabaseReady(clusterName, namespace);
+    console.log(`⏳ Waiting for database cluster '${clusterName}' to be ready...`)
+    const isReady = await this.waitForDatabaseReady(clusterName, namespace)
 
     if (isReady) {
       // Get actual credentials from the secret using direct cluster name lookup
       try {
-        const secretName = `${clusterName}-conn-credential`;
-        const secret = await this.k8sApi.readNamespacedSecret({ name: secretName, namespace });
+        const secretName = `${clusterName}-conn-credential`
+        const secret = await this.k8sApi.readNamespacedSecret({ name: secretName, namespace })
 
         // Fix: Handle both response.body.data and response.data patterns
-        const secretData = (secret as any).body?.data || (secret as any).data;
+        const secretData = (secret as any).body?.data || (secret as any).data
         if (!secretData) {
-          throw new Error(`Secret ${secretName} has no data`);
+          throw new Error(`Secret ${secretName} has no data`)
         }
 
         const dbInfo = {
@@ -252,19 +252,19 @@ export class KubernetesService {
             ? Buffer.from(secretData['password'], 'base64').toString()
             : 'postgres',
           clusterName,
-        };
+        }
 
-        console.log(`✅ Database cluster '${clusterName}' created and ready`);
-        return dbInfo;
+        console.log(`✅ Database cluster '${clusterName}' created and ready`)
+        return dbInfo
       } catch (error) {
-        console.error(`Failed to get credentials for new cluster '${clusterName}':`, error);
+        console.error(`Failed to get credentials for new cluster '${clusterName}':`, error)
       }
     }
 
     // Fallback: return connection info with defaults if not ready yet
     console.log(
       `⚠️ Database cluster '${clusterName}' not ready yet, returning default connection info`
-    );
+    )
     return {
       host: `${clusterName}-postgresql.${namespace}.svc.cluster.local`,
       port: 5432,
@@ -272,7 +272,7 @@ export class KubernetesService {
       username: 'postgres',
       password: 'postgres', // Default for KubeBlocks
       clusterName,
-    };
+    }
   }
 
   async createSandbox(
@@ -280,72 +280,72 @@ export class KubernetesService {
     envVars: Record<string, string>,
     namespace?: string,
     databaseInfo?: {
-      host: string;
-      port: number;
-      database: string;
-      username: string;
-      password: string;
-      clusterName: string;
+      host: string
+      port: number
+      database: string
+      username: string
+      password: string
+      clusterName: string
     }
   ) {
-    namespace = namespace || this.getDefaultNamespace();
-    const randomSuffix = this.generateRandomSuffix();
+    namespace = namespace || this.getDefaultNamespace()
+    const randomSuffix = this.generateRandomSuffix()
     // Convert project name to k8s-compatible format (lowercase, alphanumeric, hyphens)
     const k8sProjectName = projectName
       .toLowerCase()
       .replace(/[^a-z0-9-]/g, '')
-      .substring(0, 20);
-    const sandboxName = `${k8sProjectName}-agentruntime-${randomSuffix}`;
+      .substring(0, 20)
+    const sandboxName = `${k8sProjectName}-agentruntime-${randomSuffix}`
 
     // Generate random names for ports (based on YAML template)
-    const port3000Name = this.generateRandomName();
-    const port5000Name = this.generateRandomName();
-    const port7681Name = this.generateRandomName(); // ttyd
-    const port8080Name = this.generateRandomName();
+    const port3000Name = this.generateRandomName()
+    const port5000Name = this.generateRandomName()
+    const port7681Name = this.generateRandomName() // ttyd
+    const port8080Name = this.generateRandomName()
 
     // Generate random domains for ingress
-    const appDomain = this.generateRandomName();
-    const ttydDomain = this.generateRandomName();
+    const appDomain = this.generateRandomName()
+    const ttydDomain = this.generateRandomName()
 
     // Load Claude Code environment variables from .secret/.env
     // Check both current directory and parent directory (same as kubeconfig loading)
-    let claudeEnvPath = path.join(process.cwd(), '.secret', '.env');
+    let claudeEnvPath = path.join(process.cwd(), '.secret', '.env')
     if (!fs.existsSync(claudeEnvPath)) {
-      claudeEnvPath = path.join(process.cwd(), '..', '.secret', '.env');
+      claudeEnvPath = path.join(process.cwd(), '..', '.secret', '.env')
     }
-    let claudeEnvVars: Record<string, string> = {};
+    let claudeEnvVars: Record<string, string> = {}
 
     if (fs.existsSync(claudeEnvPath)) {
-      console.log(`Loading Claude Code env from: ${claudeEnvPath}`);
-      const envContent = fs.readFileSync(claudeEnvPath, 'utf-8');
+      console.log(`Loading Claude Code env from: ${claudeEnvPath}`)
+      const envContent = fs.readFileSync(claudeEnvPath, 'utf-8')
       envContent.split('\n').forEach((line) => {
         // Skip comment lines and export statements
-        if (line.startsWith('#') || !line.includes('=')) return;
+        if (line.startsWith('#') || !line.includes('=')) return
 
-        let cleanLine = line.replace(/^export\s+/, '');
-        const [key, ...valueParts] = cleanLine.split('=');
-        const value = valueParts.join('='); // Handle values with = signs
+        let cleanLine = line.replace(/^export\s+/, '')
+        const [key, ...valueParts] = cleanLine.split('=')
+        const value = valueParts.join('=') // Handle values with = signs
 
         if (key && value) {
-          claudeEnvVars[key.trim()] = value.trim().replace(/^["']|["']$/g, '');
+          claudeEnvVars[key.trim()] = value.trim().replace(/^["']|["']$/g, '')
         }
-      });
+      })
     }
 
     // Get database connection info for this project
-    let dbConnectionString = '';
+    let dbConnectionString = ''
     if (databaseInfo) {
       // Use provided database info (from fresh database creation)
-      dbConnectionString = `postgresql://${databaseInfo.username}:${databaseInfo.password}@${databaseInfo.host}:${databaseInfo.port}/${databaseInfo.database}?schema=public`;
-      console.log(`📊 Using provided database credentials for '${databaseInfo.clusterName}'`);
+      dbConnectionString = `postgresql://${databaseInfo.username}:${databaseInfo.password}@${databaseInfo.host}:${databaseInfo.port}/${databaseInfo.database}?schema=public`
+      console.log(`📊 Using provided database credentials for '${databaseInfo.clusterName}'`)
     } else {
       // Try to get database info for existing projects
       try {
-        const dbInfo = await this.getDatabaseSecret(k8sProjectName, namespace);
-        dbConnectionString = `postgresql://${dbInfo.username}:${dbInfo.password}@${dbInfo.host}:${dbInfo.port}/${dbInfo.database}?schema=public`;
-        console.log(`📊 Found existing database credentials for project '${k8sProjectName}'`);
+        const dbInfo = await this.getDatabaseSecret(k8sProjectName, namespace)
+        dbConnectionString = `postgresql://${dbInfo.username}:${dbInfo.password}@${dbInfo.host}:${dbInfo.port}/${dbInfo.database}?schema=public`
+        console.log(`📊 Found existing database credentials for project '${k8sProjectName}'`)
       } catch (error) {
-        console.error('Failed to get database info, will use default from environment:', error);
+        console.error('Failed to get database info, will use default from environment:', error)
         // Don't throw error - allow sandbox creation to continue with default database
       }
     }
@@ -363,44 +363,44 @@ export class KubernetesService {
       // These were causing issues with WebSocket connections
       // Pass project name for custom terminal prompt
       PROJECT_NAME: projectName,
-    };
+    }
 
     // Read kubeconfig content for ConfigMap creation
-    let kubeconfigContent = '';
+    let kubeconfigContent = ''
     try {
       // Use same path finding logic as constructor
-      let kubeconfigPath = path.join(process.cwd(), '.secret', 'kubeconfig');
+      let kubeconfigPath = path.join(process.cwd(), '.secret', 'kubeconfig')
       if (!fs.existsSync(kubeconfigPath)) {
-        kubeconfigPath = path.join(process.cwd(), '..', '.secret', 'kubeconfig');
+        kubeconfigPath = path.join(process.cwd(), '..', '.secret', 'kubeconfig')
       }
 
       if (fs.existsSync(kubeconfigPath)) {
-        kubeconfigContent = fs.readFileSync(kubeconfigPath, 'utf8');
-        console.log(`✅ Loaded kubeconfig for ConfigMap creation`);
+        kubeconfigContent = fs.readFileSync(kubeconfigPath, 'utf8')
+        console.log(`✅ Loaded kubeconfig for ConfigMap creation`)
       } else {
-        console.warn(`⚠️  Kubeconfig file not found for ConfigMap creation`);
+        console.warn(`⚠️  Kubeconfig file not found for ConfigMap creation`)
       }
     } catch (error) {
-      console.error(`❌ Failed to read kubeconfig for ConfigMap: ${error}`);
+      console.error(`❌ Failed to read kubeconfig for ConfigMap: ${error}`)
     }
 
     // Read CLAUDE.md content for ConfigMap creation
-    let claudeMdContent = '';
+    let claudeMdContent = ''
     try {
       // CLAUDE.md is in repository root (same level as fullstack-agent directory)
-      let claudeMdPath = path.join(process.cwd(), '..', 'CLAUDE.md');
+      let claudeMdPath = path.join(process.cwd(), '..', 'CLAUDE.md')
       if (!fs.existsSync(claudeMdPath)) {
-        claudeMdPath = path.join(process.cwd(), 'CLAUDE.md');
+        claudeMdPath = path.join(process.cwd(), 'CLAUDE.md')
       }
 
       if (fs.existsSync(claudeMdPath)) {
-        claudeMdContent = fs.readFileSync(claudeMdPath, 'utf8');
-        console.log(`✅ Loaded CLAUDE.md for ConfigMap creation`);
+        claudeMdContent = fs.readFileSync(claudeMdPath, 'utf8')
+        console.log(`✅ Loaded CLAUDE.md for ConfigMap creation`)
       } else {
-        console.warn(`⚠️  CLAUDE.md file not found for ConfigMap creation`);
+        console.warn(`⚠️  CLAUDE.md file not found for ConfigMap creation`)
       }
     } catch (error) {
-      console.error(`❌ Failed to read CLAUDE.md for ConfigMap: ${error}`);
+      console.error(`❌ Failed to read CLAUDE.md for ConfigMap: ${error}`)
     }
 
     // 1. Create ConfigMap with kubeconfig content
@@ -420,14 +420,14 @@ export class KubernetesService {
         data: {
           kubeconfig: kubeconfigContent,
         },
-      };
+      }
 
       try {
-        await this.k8sApi.createNamespacedConfigMap({ namespace, body: configMap as any });
-        console.log(`✅ Created ConfigMap: ${sandboxName}-kubeconfig`);
+        await this.k8sApi.createNamespacedConfigMap({ namespace, body: configMap as any })
+        console.log(`✅ Created ConfigMap: ${sandboxName}-kubeconfig`)
       } catch (error) {
-        console.error(`❌ Failed to create ConfigMap: ${error}`);
-        throw error;
+        console.error(`❌ Failed to create ConfigMap: ${error}`)
+        throw error
       }
     }
 
@@ -448,14 +448,14 @@ export class KubernetesService {
         data: {
           'CLAUDE.md': claudeMdContent,
         },
-      };
+      }
 
       try {
-        await this.k8sApi.createNamespacedConfigMap({ namespace, body: claudeMdConfigMap as any });
-        console.log(`✅ Created ConfigMap: ${sandboxName}-claude-md`);
+        await this.k8sApi.createNamespacedConfigMap({ namespace, body: claudeMdConfigMap as any })
+        console.log(`✅ Created ConfigMap: ${sandboxName}-claude-md`)
       } catch (error) {
-        console.error(`❌ Failed to create CLAUDE.md ConfigMap: ${error}`);
-        throw error;
+        console.error(`❌ Failed to create CLAUDE.md ConfigMap: ${error}`)
+        throw error
       }
     }
 
@@ -463,7 +463,7 @@ export class KubernetesService {
     const currentTime = new Date()
       .toISOString()
       .replace(/[-:T.]/g, '')
-      .substring(0, 14);
+      .substring(0, 14)
 
     const statefulSet = {
       apiVersion: 'apps/v1',
@@ -510,6 +510,11 @@ export class KubernetesService {
           spec: {
             automountServiceAccountToken: false,
             terminationGracePeriodSeconds: 10,
+            securityContext: {
+              fsGroup: 1001, // Group ownership for mounted volumes (matches agent user GID)
+              runAsUser: 1001, // Explicit UID for agent user
+              runAsNonRoot: true, // Security best practice
+            },
             containers: [
               {
                 name: sandboxName,
@@ -542,34 +547,34 @@ export class KubernetesService {
                   postStart: {
                     exec: {
                       command: (() => {
-                        const commands = [];
+                        const commands = []
 
                         // Handle kubeconfig
                         if (kubeconfigContent) {
                           commands.push(
                             'mkdir -p /home/agent/.kube && cp /tmp/kubeconfig/kubeconfig /home/agent/.kube/config'
-                          );
+                          )
                         }
 
                         // Handle CLAUDE.md
                         if (claudeMdContent) {
-                          commands.push('cp /tmp/claude-md/CLAUDE.md /home/agent/CLAUDE.md');
+                          commands.push('cp /tmp/claude-md/CLAUDE.md /home/agent/CLAUDE.md')
                         }
 
                         // Fallbacks for missing files
                         if (!kubeconfigContent && !claudeMdContent) {
                           commands.push(
                             'mkdir -p /home/agent/.kube && touch /home/agent/.kube/config'
-                          );
+                          )
                         } else if (!kubeconfigContent && claudeMdContent) {
                           commands.push(
                             'mkdir -p /home/agent/.kube && touch /home/agent/.kube/config'
-                          );
+                          )
                         } else if (kubeconfigContent && !claudeMdContent) {
                           // kubeconfig already handled, no additional fallback needed
                         }
 
-                        return ['sh', '-c', commands.join(' && ')];
+                        return ['sh', '-c', commands.join(' && ')]
                       })(),
                     },
                   },
@@ -643,12 +648,12 @@ export class KubernetesService {
           },
         ],
       },
-    };
+    }
 
-    await this.k8sAppsApi.createNamespacedStatefulSet({ namespace, body: statefulSet as any });
+    await this.k8sAppsApi.createNamespacedStatefulSet({ namespace, body: statefulSet as any })
 
     // 2. Create Service with Sealos labels
-    const serviceName = `${sandboxName}-service`;
+    const serviceName = `${sandboxName}-service`
     const service = {
       apiVersion: 'v1',
       kind: 'Service',
@@ -691,9 +696,9 @@ export class KubernetesService {
           app: sandboxName,
         },
       },
-    };
+    }
 
-    await this.k8sApi.createNamespacedService({ namespace, body: service as any });
+    await this.k8sApi.createNamespacedService({ namespace, body: service as any })
 
     // 3. Create multiple Ingress resources (one for each port)
     const ingresses = [
@@ -806,11 +811,11 @@ export class KubernetesService {
           ],
         },
       },
-    ];
+    ]
 
     // Create each ingress
     for (const ingress of ingresses) {
-      await this.k8sNetworkingApi.createNamespacedIngress({ namespace, body: ingress as any });
+      await this.k8sNetworkingApi.createNamespacedIngress({ namespace, body: ingress as any })
     }
 
     return {
@@ -818,11 +823,11 @@ export class KubernetesService {
       serviceName: serviceName,
       publicUrl: `https://${appDomain}.usw.sealos.io`,
       ttydUrl: `https://${ttydDomain}.usw.sealos.io`,
-    };
+    }
   }
 
   async deleteSandbox(projectName: string, namespace?: string) {
-    namespace = namespace || this.getDefaultNamespace();
+    namespace = namespace || this.getDefaultNamespace()
 
     try {
       // Find all resources related to this project
@@ -830,59 +835,59 @@ export class KubernetesService {
       const k8sProjectName = projectName
         .toLowerCase()
         .replace(/[^a-z0-9-]/g, '')
-        .substring(0, 20);
-      console.log(`🗑️ Deleting sandbox for project: ${projectName} (k8s: ${k8sProjectName})`);
+        .substring(0, 20)
+      console.log(`🗑️ Deleting sandbox for project: ${projectName} (k8s: ${k8sProjectName})`)
 
       // Delete StatefulSets
-      const statefulSets = await this.k8sAppsApi.listNamespacedStatefulSet({ namespace });
+      const statefulSets = await this.k8sAppsApi.listNamespacedStatefulSet({ namespace })
       // Fix: Handle both response.body.items and response.items patterns for StatefulSet
-      const statefulSetItems = (statefulSets as any).body?.items || statefulSets.items || [];
+      const statefulSetItems = (statefulSets as any).body?.items || statefulSets.items || []
       console.log(
         `📦 StatefulSets response:`,
         (statefulSets as any).body ? 'has body' : 'no body',
         statefulSetItems.length,
         'items'
-      );
+      )
       const projectStatefulSets = statefulSetItems.filter((sts: any) =>
         sts.metadata.name.startsWith(`${k8sProjectName}-agentruntime-`)
-      );
+      )
 
       for (const statefulSet of projectStatefulSets) {
         try {
           await this.k8sAppsApi.deleteNamespacedStatefulSet({
             name: statefulSet.metadata.name,
             namespace,
-          });
-          console.log(`Deleted StatefulSet: ${statefulSet.metadata.name}`);
+          })
+          console.log(`Deleted StatefulSet: ${statefulSet.metadata.name}`)
         } catch (error) {
-          console.error(`Failed to delete StatefulSet ${statefulSet.metadata.name}:`, error);
+          console.error(`Failed to delete StatefulSet ${statefulSet.metadata.name}:`, error)
         }
       }
 
       // Delete Services
-      const services = await this.k8sApi.listNamespacedService({ namespace });
+      const services = await this.k8sApi.listNamespacedService({ namespace })
       // Fix: Handle both response.body.items and response.items patterns
-      const serviceItems = services.body?.items || (services as any).items || [];
+      const serviceItems = services.body?.items || (services as any).items || []
       const projectServices = serviceItems.filter((svc: any) =>
         svc.metadata.name.startsWith(`${k8sProjectName}-agentruntime-`)
-      );
+      )
 
       for (const service of projectServices) {
         try {
           await this.k8sApi.deleteNamespacedService({
             name: service.metadata.name,
             namespace,
-          });
-          console.log(`Deleted service: ${service.metadata.name}`);
+          })
+          console.log(`Deleted service: ${service.metadata.name}`)
         } catch (error) {
-          console.error(`Failed to delete service ${service.metadata.name}:`, error);
+          console.error(`Failed to delete service ${service.metadata.name}:`, error)
         }
       }
 
       // Delete Ingresses
-      const ingresses = await this.k8sNetworkingApi.listNamespacedIngress({ namespace });
+      const ingresses = await this.k8sNetworkingApi.listNamespacedIngress({ namespace })
       // Fix: Handle both response.body.items and response.items patterns
-      const ingressItems = ingresses.body?.items || (ingresses as any).items || [];
+      const ingressItems = ingresses.body?.items || (ingresses as any).items || []
       const projectIngresses = ingressItems.filter(
         (ing: any) =>
           ing.metadata.labels &&
@@ -890,86 +895,86 @@ export class KubernetesService {
           ing.metadata.labels['cloud.sealos.io/app-deploy-manager'].startsWith(
             `${k8sProjectName}-agentruntime-`
           )
-      );
+      )
 
       for (const ingress of projectIngresses) {
         try {
           await this.k8sNetworkingApi.deleteNamespacedIngress({
             name: ingress.metadata.name,
             namespace,
-          });
-          console.log(`Deleted ingress: ${ingress.metadata.name}`);
+          })
+          console.log(`Deleted ingress: ${ingress.metadata.name}`)
         } catch (error) {
-          console.error(`Failed to delete ingress ${ingress.metadata.name}:`, error);
+          console.error(`Failed to delete ingress ${ingress.metadata.name}:`, error)
         }
       }
 
       // Delete ConfigMaps (kubeconfig + CLAUDE.md)
       try {
-        const configMaps = await this.k8sApi.listNamespacedConfigMap({ namespace });
-        const configMapItems = configMaps.body?.items || (configMaps as any).items || [];
+        const configMaps = await this.k8sApi.listNamespacedConfigMap({ namespace })
+        const configMapItems = configMaps.body?.items || (configMaps as any).items || []
         const projectConfigMaps = configMapItems.filter(
           (cm: any) =>
             cm.metadata.name.startsWith(`${k8sProjectName}-agentruntime-`) &&
             (cm.metadata.name.endsWith('-kubeconfig') || cm.metadata.name.endsWith('-claude-md'))
-        );
+        )
 
         for (const configMap of projectConfigMaps) {
           try {
             await this.k8sApi.deleteNamespacedConfigMap({
               name: configMap.metadata.name,
               namespace,
-            });
-            console.log(`Deleted ConfigMap: ${configMap.metadata.name}`);
+            })
+            console.log(`Deleted ConfigMap: ${configMap.metadata.name}`)
           } catch (error) {
-            console.error(`Failed to delete ConfigMap ${configMap.metadata.name}:`, error);
+            console.error(`Failed to delete ConfigMap ${configMap.metadata.name}:`, error)
           }
         }
       } catch (error) {
-        console.error('Failed to list or delete ConfigMaps:', error);
+        console.error('Failed to list or delete ConfigMaps:', error)
       }
     } catch (error) {
-      console.error('Failed to delete sandbox resources:', error);
+      console.error('Failed to delete sandbox resources:', error)
     }
   }
 
   async getSandboxStatus(projectName: string, namespace?: string) {
-    namespace = namespace || this.getDefaultNamespace();
+    namespace = namespace || this.getDefaultNamespace()
 
     try {
       // Convert project name to k8s-compatible format
       const k8sProjectName = projectName
         .toLowerCase()
         .replace(/[^a-z0-9-]/g, '')
-        .substring(0, 20);
+        .substring(0, 20)
 
       // Find StatefulSet with new naming pattern
-      const statefulSets = await this.k8sAppsApi.listNamespacedStatefulSet({ namespace });
+      const statefulSets = await this.k8sAppsApi.listNamespacedStatefulSet({ namespace })
       // Fix: Handle both response.body.items and response.items patterns for StatefulSet
-      const statefulSetItems = (statefulSets as any).body?.items || statefulSets.items || [];
+      const statefulSetItems = (statefulSets as any).body?.items || statefulSets.items || []
       const projectStatefulSet = statefulSetItems.find((sts: any) =>
         sts.metadata.name.startsWith(`${k8sProjectName}-agentruntime-`)
-      );
+      )
 
       if (!projectStatefulSet) {
-        return 'TERMINATED';
+        return 'TERMINATED'
       }
 
-      const replicas = projectStatefulSet.status?.replicas || 0;
-      const readyReplicas = projectStatefulSet.status?.readyReplicas || 0;
+      const replicas = projectStatefulSet.status?.replicas || 0
+      const readyReplicas = projectStatefulSet.status?.readyReplicas || 0
 
       if (readyReplicas === replicas && replicas > 0) {
-        return 'RUNNING';
+        return 'RUNNING'
       } else if (replicas === 0) {
-        return 'STOPPED';
+        return 'STOPPED'
       } else {
-        return 'CREATING';
+        return 'CREATING'
       }
     } catch (error: any) {
       if (error?.response?.statusCode === 404) {
-        return 'TERMINATED';
+        return 'TERMINATED'
       }
-      return 'ERROR';
+      return 'ERROR'
     }
   }
 
@@ -978,11 +983,11 @@ export class KubernetesService {
     namespace?: string,
     timeoutMs: number = 120000
   ): Promise<boolean> {
-    namespace = namespace || this.getDefaultNamespace();
-    const startTime = Date.now();
-    const customObjectsApi = this.kc.makeApiClient(k8s.CustomObjectsApi);
+    namespace = namespace || this.getDefaultNamespace()
+    const startTime = Date.now()
+    const customObjectsApi = this.kc.makeApiClient(k8s.CustomObjectsApi)
 
-    console.log(`⏳ Waiting for database cluster '${clusterName}' to be ready...`);
+    console.log(`⏳ Waiting for database cluster '${clusterName}' to be ready...`)
 
     while (Date.now() - startTime < timeoutMs) {
       try {
@@ -993,35 +998,35 @@ export class KubernetesService {
           namespace: namespace,
           plural: 'clusters',
           name: clusterName,
-        });
+        })
 
-        const clusterObj = cluster.body || cluster;
-        const status = (clusterObj as any)?.status?.phase;
+        const clusterObj = cluster.body || cluster
+        const status = (clusterObj as any)?.status?.phase
 
-        console.log(`📊 Cluster '${clusterName}' status: ${status}`);
+        console.log(`📊 Cluster '${clusterName}' status: ${status}`)
 
         if (status === 'Running') {
           // Also check if the connection secret exists
-          const secretName = `${clusterName}-conn-credential`;
+          const secretName = `${clusterName}-conn-credential`
           try {
-            await this.k8sApi.readNamespacedSecret({ name: secretName, namespace });
-            console.log(`✅ Database cluster '${clusterName}' is ready with credentials`);
-            return true;
+            await this.k8sApi.readNamespacedSecret({ name: secretName, namespace })
+            console.log(`✅ Database cluster '${clusterName}' is ready with credentials`)
+            return true
           } catch (secretError) {
-            console.log(`⏳ Cluster running but credentials not ready yet...`);
+            console.log(`⏳ Cluster running but credentials not ready yet...`)
           }
         }
 
         // Wait 3 seconds before checking again
-        await new Promise((resolve) => setTimeout(resolve, 3000));
+        await new Promise((resolve) => setTimeout(resolve, 3000))
       } catch (error) {
-        console.log(`⏳ Cluster not found yet, continuing to wait...`);
-        await new Promise((resolve) => setTimeout(resolve, 3000));
+        console.log(`⏳ Cluster not found yet, continuing to wait...`)
+        await new Promise((resolve) => setTimeout(resolve, 3000))
       }
     }
 
-    console.log(`⚠️ Timeout waiting for database cluster '${clusterName}' to be ready`);
-    return false;
+    console.log(`⚠️ Timeout waiting for database cluster '${clusterName}' to be ready`)
+    return false
   }
 
   async updateStatefulSetEnvVars(
@@ -1029,54 +1034,54 @@ export class KubernetesService {
     namespace: string,
     envVars: Record<string, string>
   ) {
-    namespace = namespace || this.getDefaultNamespace();
+    namespace = namespace || this.getDefaultNamespace()
 
     // Convert project name to k8s-compatible format
     const k8sProjectName = projectName
       .toLowerCase()
       .replace(/[^a-z0-9-]/g, '')
-      .substring(0, 20);
+      .substring(0, 20)
 
     try {
       // Find the StatefulSet for this project
-      const statefulSets = await this.k8sAppsApi.listNamespacedStatefulSet({ namespace });
-      const statefulSetItems = (statefulSets as any).body?.items || statefulSets.items || [];
+      const statefulSets = await this.k8sAppsApi.listNamespacedStatefulSet({ namespace })
+      const statefulSetItems = (statefulSets as any).body?.items || statefulSets.items || []
       const projectStatefulSet = statefulSetItems.find((sts: any) =>
         sts.metadata.name.startsWith(`${k8sProjectName}-agentruntime-`)
-      );
+      )
 
       if (!projectStatefulSet) {
-        throw new Error(`No StatefulSet found for project ${projectName}`);
+        throw new Error(`No StatefulSet found for project ${projectName}`)
       }
 
-      const statefulSetName = projectStatefulSet.metadata.name;
+      const statefulSetName = projectStatefulSet.metadata.name
 
       // Load Claude Code environment variables from .secret/.env
-      const claudeEnvPath = path.join(process.cwd(), '.secret', '.env');
-      let claudeEnvVars: Record<string, string> = {};
+      const claudeEnvPath = path.join(process.cwd(), '.secret', '.env')
+      let claudeEnvVars: Record<string, string> = {}
 
       if (fs.existsSync(claudeEnvPath)) {
-        const envContent = fs.readFileSync(claudeEnvPath, 'utf-8');
+        const envContent = fs.readFileSync(claudeEnvPath, 'utf-8')
         envContent.split('\n').forEach((line) => {
-          if (line.startsWith('#') || !line.includes('=')) return;
+          if (line.startsWith('#') || !line.includes('=')) return
 
-          let cleanLine = line.replace(/^export\s+/, '');
-          const [key, ...valueParts] = cleanLine.split('=');
-          const value = valueParts.join('=');
+          let cleanLine = line.replace(/^export\s+/, '')
+          const [key, ...valueParts] = cleanLine.split('=')
+          const value = valueParts.join('=')
 
           if (key && value) {
-            claudeEnvVars[key.trim()] = value.trim().replace(/^["']|["']$/g, '');
+            claudeEnvVars[key.trim()] = value.trim().replace(/^["']|["']$/g, '')
           }
-        });
+        })
       }
 
       // Get database connection string if available
-      let dbConnectionString = '';
+      let dbConnectionString = ''
       try {
-        const dbInfo = await this.getDatabaseSecret(k8sProjectName, namespace);
-        dbConnectionString = `postgresql://${dbInfo.username}:${dbInfo.password}@${dbInfo.host}:${dbInfo.port}/${dbInfo.database}?schema=public`;
+        const dbInfo = await this.getDatabaseSecret(k8sProjectName, namespace)
+        dbConnectionString = `postgresql://${dbInfo.username}:${dbInfo.password}@${dbInfo.host}:${dbInfo.port}/${dbInfo.database}?schema=public`
       } catch (error) {
-        console.log('Could not get database info for environment update');
+        console.log('Could not get database info for environment update')
       }
 
       // Merge all environment variables
@@ -1087,7 +1092,7 @@ export class KubernetesService {
         NODE_ENV: 'development',
         TTYD_PORT: '7681',
         TTYD_INTERFACE: '0.0.0.0',
-      };
+      }
 
       // Update the StatefulSet with new environment variables
       const updatedStatefulSet = {
@@ -1106,57 +1111,57 @@ export class KubernetesService {
                       name: key,
                       value: String(value),
                     })),
-                  };
+                  }
                 }
-                return container;
+                return container
               }),
             },
           },
         },
-      };
+      }
 
       // Apply the update
       await this.k8sAppsApi.replaceNamespacedStatefulSet({
         name: statefulSetName,
         namespace,
         body: updatedStatefulSet,
-      });
+      })
 
-      console.log(`✅ Updated StatefulSet ${statefulSetName} with new environment variables`);
+      console.log(`✅ Updated StatefulSet ${statefulSetName} with new environment variables`)
 
       // The StatefulSet will automatically restart the pods with new environment variables
-      return true;
+      return true
     } catch (error) {
-      console.error(`Failed to update StatefulSet environment variables:`, error);
-      throw error;
+      console.error(`Failed to update StatefulSet environment variables:`, error)
+      throw error
     }
   }
 
   async getDatabaseSecret(projectName: string, namespace?: string) {
-    namespace = namespace || this.getDefaultNamespace();
+    namespace = namespace || this.getDefaultNamespace()
 
     // Convert project name to k8s-compatible format
     const k8sProjectName = projectName
       .toLowerCase()
       .replace(/[^a-z0-9-]/g, '')
-      .substring(0, 20);
-    console.log(`🔍 Getting database secret for project: ${projectName} (k8s: ${k8sProjectName})`);
+      .substring(0, 20)
+    console.log(`🔍 Getting database secret for project: ${projectName} (k8s: ${k8sProjectName})`)
 
     // For KubeBlocks clusters, we need to find the cluster by project name
     // The cluster name follows pattern: [k8sProjectName]-agentruntime-[6chars]
     try {
-      const customObjectsApi = this.kc.makeApiClient(k8s.CustomObjectsApi);
+      const customObjectsApi = this.kc.makeApiClient(k8s.CustomObjectsApi)
       const clusters = await customObjectsApi.listNamespacedCustomObject({
         group: 'apps.kubeblocks.io',
         version: 'v1alpha1',
         namespace: namespace,
         plural: 'clusters',
-      });
+      })
 
       // CRITICAL FIX: The response structure varies by client version
       // Check if response has body property or items directly on response
-      const clusterList = clusters.body || clusters;
-      const clusterItems = (clusterList as any)?.items || [];
+      const clusterList = clusters.body || clusters
+      const clusterItems = (clusterList as any)?.items || []
 
       console.log(
         `🗄️ KubeBlocks clusters response:`,
@@ -1164,55 +1169,55 @@ export class KubernetesService {
         clusterList ? 'has cluster list' : 'no cluster list',
         clusterItems.length > 0 ? `${clusterItems.length} items` : 'no items',
         clusterList ? `response keys: ${Object.keys(clusterList)}` : 'no cluster list keys'
-      );
+      )
 
       if (!Array.isArray(clusterItems)) {
         console.error(
           `❌ Expected clusters.body.items to be an array, got:`,
           typeof clusterItems,
           clusterItems
-        );
-        throw new Error(`Invalid API response: expected items array, got ${typeof clusterItems}`);
+        )
+        throw new Error(`Invalid API response: expected items array, got ${typeof clusterItems}`)
       }
 
       // Try to find cluster with multiple naming patterns
       let projectCluster = clusterItems.find((cluster: any) =>
         cluster?.metadata?.name?.startsWith(`${k8sProjectName}-agentruntime-`)
-      );
+      )
 
       // Fallback: Try simple project name pattern
       if (!projectCluster) {
         projectCluster = clusterItems.find(
           (cluster: any) => cluster?.metadata?.name === k8sProjectName
-        );
+        )
       }
 
       // Fallback: Try exact project name match (for original project names)
       if (!projectCluster && projectName !== k8sProjectName) {
         projectCluster = clusterItems.find(
           (cluster: any) => cluster?.metadata?.name === projectName
-        );
+        )
       }
 
       if (!projectCluster) {
-        const availableClusters = clusterItems.map((c: any) => c?.metadata?.name).join(', ');
+        const availableClusters = clusterItems.map((c: any) => c?.metadata?.name).join(', ')
         throw new Error(
           `No database cluster found for project ${projectName} (k8s name: ${k8sProjectName}). Available clusters: ${availableClusters}`
-        );
+        )
       }
 
-      const clusterName = projectCluster.metadata.name;
+      const clusterName = projectCluster.metadata.name
 
       // KubeBlocks creates a secret with connection info
-      const secretName = `${clusterName}-conn-credential`;
+      const secretName = `${clusterName}-conn-credential`
 
       try {
-        const secret = await this.k8sApi.readNamespacedSecret({ name: secretName, namespace });
+        const secret = await this.k8sApi.readNamespacedSecret({ name: secretName, namespace })
 
         // Fix: Handle both response.body and direct response patterns
-        const secretData = secret.body?.data || (secret as any).data;
+        const secretData = secret.body?.data || (secret as any).data
         if (!secretData) {
-          throw new Error(`Secret ${secretName} has no data`);
+          throw new Error(`Secret ${secretName} has no data`)
         }
 
         return {
@@ -1222,7 +1227,7 @@ export class KubernetesService {
           username: Buffer.from(secretData['username'], 'base64').toString(),
           password: Buffer.from(secretData['password'], 'base64').toString(),
           clusterName,
-        };
+        }
       } catch (secretError) {
         // Fallback to default connection info if secret doesn't exist yet
         return {
@@ -1232,53 +1237,53 @@ export class KubernetesService {
           username: 'postgres',
           password: 'postgres', // Default for KubeBlocks
           clusterName,
-        };
+        }
       }
     } catch (error) {
-      throw new Error(`Failed to get database secret: ${error}`);
+      throw new Error(`Failed to get database secret: ${error}`)
     }
   }
 
   // Generate random string for port names and domains (12 characters, lowercase letters)
   private generateRandomName(length: number = 12): string {
-    const charset = 'abcdefghijklmnopqrstuvwxyz';
-    let result = '';
+    const charset = 'abcdefghijklmnopqrstuvwxyz'
+    let result = ''
     for (let i = 0; i < length; i++) {
-      result += charset.charAt(Math.floor(Math.random() * charset.length));
+      result += charset.charAt(Math.floor(Math.random() * charset.length))
     }
-    return result;
+    return result
   }
 
   async stopSandbox(projectName: string, namespace?: string) {
-    namespace = namespace || this.getDefaultNamespace();
+    namespace = namespace || this.getDefaultNamespace()
 
     try {
       // Convert project name to k8s-compatible format
       const k8sProjectName = projectName
         .toLowerCase()
         .replace(/[^a-z0-9-]/g, '')
-        .substring(0, 20);
-      console.log(`⏸️ Stopping sandbox for project: ${projectName} (k8s: ${k8sProjectName})`);
+        .substring(0, 20)
+      console.log(`⏸️ Stopping sandbox for project: ${projectName} (k8s: ${k8sProjectName})`)
 
       // Find the StatefulSet for this project
-      const statefulSets = await this.k8sAppsApi.listNamespacedStatefulSet({ namespace });
-      const statefulSetItems = (statefulSets as any).body?.items || statefulSets.items || [];
+      const statefulSets = await this.k8sAppsApi.listNamespacedStatefulSet({ namespace })
+      const statefulSetItems = (statefulSets as any).body?.items || statefulSets.items || []
       console.log(
         `🔍 Looking for StatefulSets matching: ${k8sProjectName}-agentruntime-* in namespace ${namespace}`
-      );
-      console.log(`📋 Found ${statefulSetItems.length} StatefulSets total:`);
+      )
+      console.log(`📋 Found ${statefulSetItems.length} StatefulSets total:`)
       statefulSetItems.forEach((sts: any) => {
-        console.log(`  - ${sts.metadata.name} (${sts.spec.replicas} replicas)`);
-      });
+        console.log(`  - ${sts.metadata.name} (${sts.spec.replicas} replicas)`)
+      })
       const projectStatefulSet = statefulSetItems.find((sts: any) =>
         sts.metadata.name.startsWith(`${k8sProjectName}-agentruntime-`)
-      );
+      )
 
       if (!projectStatefulSet) {
-        throw new Error(`No StatefulSet found for project ${projectName}`);
+        throw new Error(`No StatefulSet found for project ${projectName}`)
       }
 
-      const statefulSetName = projectStatefulSet.metadata.name;
+      const statefulSetName = projectStatefulSet.metadata.name
 
       // Scale down to 0 replicas by replacing the StatefulSet
       const updatedStatefulSet = {
@@ -1287,44 +1292,44 @@ export class KubernetesService {
           ...projectStatefulSet.spec,
           replicas: 0,
         },
-      };
+      }
 
       await this.k8sAppsApi.replaceNamespacedStatefulSet({
         name: statefulSetName,
         namespace,
         body: updatedStatefulSet,
-      });
+      })
 
-      console.log(`✅ Stopped StatefulSet: ${statefulSetName} (scaled to 0 replicas)`);
+      console.log(`✅ Stopped StatefulSet: ${statefulSetName} (scaled to 0 replicas)`)
     } catch (error) {
-      console.error(`Failed to stop sandbox:`, error);
-      throw error;
+      console.error(`Failed to stop sandbox:`, error)
+      throw error
     }
   }
 
   async startSandbox(projectName: string, namespace?: string) {
-    namespace = namespace || this.getDefaultNamespace();
+    namespace = namespace || this.getDefaultNamespace()
 
     try {
       // Convert project name to k8s-compatible format
       const k8sProjectName = projectName
         .toLowerCase()
         .replace(/[^a-z0-9-]/g, '')
-        .substring(0, 20);
-      console.log(`▶️ Starting sandbox for project: ${projectName} (k8s: ${k8sProjectName})`);
+        .substring(0, 20)
+      console.log(`▶️ Starting sandbox for project: ${projectName} (k8s: ${k8sProjectName})`)
 
       // Find the StatefulSet for this project
-      const statefulSets = await this.k8sAppsApi.listNamespacedStatefulSet({ namespace });
-      const statefulSetItems = (statefulSets as any).body?.items || statefulSets.items || [];
+      const statefulSets = await this.k8sAppsApi.listNamespacedStatefulSet({ namespace })
+      const statefulSetItems = (statefulSets as any).body?.items || statefulSets.items || []
       const projectStatefulSet = statefulSetItems.find((sts: any) =>
         sts.metadata.name.startsWith(`${k8sProjectName}-agentruntime-`)
-      );
+      )
 
       if (!projectStatefulSet) {
-        throw new Error(`No StatefulSet found for project ${projectName}`);
+        throw new Error(`No StatefulSet found for project ${projectName}`)
       }
 
-      const statefulSetName = projectStatefulSet.metadata.name;
+      const statefulSetName = projectStatefulSet.metadata.name
 
       // Scale up to 1 replica
       await this.k8sAppsApi.patchNamespacedStatefulSet({
@@ -1335,24 +1340,24 @@ export class KubernetesService {
             replicas: 1,
           },
         },
-      });
+      })
 
-      console.log(`✅ Started StatefulSet: ${statefulSetName} (scaled to 1 replica)`);
+      console.log(`✅ Started StatefulSet: ${statefulSetName} (scaled to 1 replica)`)
     } catch (error) {
-      console.error(`Failed to start sandbox:`, error);
-      throw error;
+      console.error(`Failed to start sandbox:`, error)
+      throw error
     }
   }
 
   // Generate 6-character random suffix for resource names
   private generateRandomSuffix(): string {
-    const charset = 'abcdefghijklmnopqrstuvwxyz0123456789';
-    let result = '';
+    const charset = 'abcdefghijklmnopqrstuvwxyz0123456789'
+    let result = ''
     for (let i = 0; i < 6; i++) {
-      result += charset.charAt(Math.floor(Math.random() * charset.length));
+      result += charset.charAt(Math.floor(Math.random() * charset.length))
     }
-    return result;
+    return result
   }
 }
 
-export const k8sService = new KubernetesService();
+export const k8sService = new KubernetesService()

--- a/lib/versions.ts
+++ b/lib/versions.ts
@@ -5,15 +5,15 @@
 
 const VERSIONS = {
   // Runtime container image version
-  RUNTIME_IMAGE: 'fullstackagent/fullstack-web-runtime:v0.0.1-alpha.10',
-} as const;
+  RUNTIME_IMAGE: 'fullstackagent/fullstack-web-runtime:v0.0.1-alpha.11',
+} as const
 
 /**
  * Get the current runtime image with tag
  * @returns The full image name with tag
  */
 export function getRuntimeImage(): string {
-  return VERSIONS.RUNTIME_IMAGE;
+  return VERSIONS.RUNTIME_IMAGE
 }
 
 /**
@@ -21,7 +21,7 @@ export function getRuntimeImage(): string {
  * @returns The image name without version tag
  */
 export function getRuntimeImageName(): string {
-  return VERSIONS.RUNTIME_IMAGE.split(':')[0];
+  return VERSIONS.RUNTIME_IMAGE.split(':')[0]
 }
 
 /**
@@ -29,5 +29,5 @@ export function getRuntimeImageName(): string {
  * @returns The version tag
  */
 export function getRuntimeImageTag(): string {
-  return VERSIONS.RUNTIME_IMAGE.split(':')[1] || 'latest';
+  return VERSIONS.RUNTIME_IMAGE.split(':')[1] || 'latest'
 }


### PR DESCRIPTION
## Summary
- Bumps runtime image version from v0.0.1-alpha.10 to v0.0.1-alpha.11
- Adds pod security context to fix permission issues with mounted volumes
- Refactors kubernetes.ts code style for consistency

## Changes
### Security Improvements
- Added `securityContext` to StatefulSet pod spec:
  - `fsGroup: 1001` - Ensures group ownership for mounted volumes matches agent user
  - `runAsUser: 1001` - Explicitly runs containers as agent user (non-root)
  - `runAsNonRoot: true` - Enforces security best practice

### Version Updates
- Updated GitHub workflow to build v0.0.1-alpha.11
- Updated version configuration in lib/versions.ts

### Code Style
- Removed semicolons throughout lib/kubernetes.ts for consistency

## Related Issues
Fixes #30 - PostStartHookError with mkdir permission denied

The added security context ensures that mounted volumes (ConfigMaps for kubeconfig and CLAUDE.md) have proper permissions for the agent user, preventing the mkdir permission errors seen in the PostStartHook.

## Test Plan
- [ ] Deploy sandbox with new runtime version
- [ ] Verify kubeconfig and CLAUDE.md are properly mounted and accessible
- [ ] Verify no PostStartHook errors in pod logs
- [ ] Confirm ttyd terminal starts successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)