### PR TITLE
chore: Bump runtime version to v0.0.1-alpha.12 with initialization improvements

### DIFF
--- a/.github/workflows/build-runtime-manual.yml
+++ b/.github/workflows/build-runtime-manual.yml
@@ -1,4 +1,4 @@
-name: Manual Build Runtime v0.0.1-alpha.11
+name: Manual Build Runtime v0.0.1-alpha.12
 
 on:
   workflow_dispatch:
@@ -11,7 +11,7 @@ on:
 env:
   DOCKER_REGISTRY: docker.io
   IMAGE_NAME: fullstackagent/fullstack-web-runtime
-  IMAGE_TAG: v0.0.1-alpha.11
+  IMAGE_TAG: v0.0.1-alpha.12
 
 jobs:
   build-and-push:
@@ -43,7 +43,7 @@ jobs:
           push: true
           tags: |
             ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
-            ${{ env.IMAGE_NAME }}:0.0.1-alpha.11
+            ${{ env.IMAGE_NAME }}:0.0.1-alpha.12
             ${{ env.IMAGE_NAME }}:0.0.1
             ${{ env.IMAGE_NAME }}:latest
           labels: |
@@ -61,7 +61,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Image Tags:**" >> $GITHUB_STEP_SUMMARY
           echo "- \`${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- \`${{ env.IMAGE_NAME }}:0.0.1-alpha.10\`" >> $GITHUB_STEP_SUMMARY
+          echo "- \`${{ env.IMAGE_NAME }}:0.0.1-alpha.12\`" >> $GITHUB_STEP_SUMMARY
           echo "- \`${{ env.IMAGE_NAME }}:latest\`" >> $GITHUB_STEP_SUMMARY
           echo "- \`${{ env.IMAGE_NAME }}:0.0.1\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/lib/versions.ts
+++ b/lib/versions.ts
@@ -5,7 +5,7 @@
 
 const VERSIONS = {
   // Runtime container image version
-  RUNTIME_IMAGE: 'fullstackagent/fullstack-web-runtime:v0.0.1-alpha.11',
+  RUNTIME_IMAGE: 'fullstackagent/fullstack-web-runtime:v0.0.1-alpha.12',
 } as const
 
 /**

--- a/runtime/Dockerfile
+++ b/runtime/Dockerfile
@@ -67,7 +67,8 @@ RUN npm install -g \
     postcss
 
 # Set up a non-root user for better security (must be before creating user-specific directories)
-RUN useradd -m -s /bin/bash agent && \
+RUN groupadd -g 1001 agent && \
+    useradd -u 1001 -g 1001 -m -s /bin/bash agent && \
     echo 'agent ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 # Install Buildah and related container tools for unprivileged operation
@@ -146,7 +147,7 @@ WORKDIR /home/agent
 
 # Copy entrypoint script and bash configuration
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
-COPY .bashrc /home/agent/.bashrc
+COPY .bashrc /etc/skel/.bashrc
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
 # Set default user to agent


### PR DESCRIPTION
## Summary

- Bump runtime version to v0.0.1-alpha.12
- Replace postStart lifecycle hook with initContainer for reliable file initialization
- Set explicit UID/GID (1001:1001) for agent user
- Move .bashrc to /etc/skel to survive volume mounts

## Technical Changes

### InitContainer Pattern
The postStart lifecycle hook has been replaced with a proper initContainer. This ensures:
- All file operations complete before the main container starts
- No race conditions between container startup and file copying
- Proper error handling and visibility if initialization fails
- Clean separation of privileged (init) and unprivileged (main) operations

### Permission Improvements
- Explicit UID/GID (1001:1001) for the agent user in Dockerfile
- initContainer runs as root to properly set ownership
- Main container runs as unprivileged user (1001:1001)
- .bashrc moved to `/etc/skel` so it's not overwritten by volume mounts

### Files Changed
- [.github/workflows/build-runtime-manual.yml](.github/workflows/build-runtime-manual.yml) - Updated version references
- [lib/kubernetes.ts](lib/kubernetes.ts#L508-L582) - Added initContainer, removed postStart hook
- [lib/versions.ts](lib/versions.ts#L8) - Updated RUNTIME_IMAGE to v0.0.1-alpha.12
- [runtime/Dockerfile](runtime/Dockerfile#L70-L150) - Explicit UID/GID, moved .bashrc location

## Test Plan

- [x] Build and push runtime image v0.0.1-alpha.12 via GitHub Actions
- [x] Deploy main app with updated version reference
- [x] Create new sandbox project
- [x] Verify terminal access works (ttyd)
- [x] Verify .bashrc is loaded and Claude Code CLI auto-starts
- [x] Verify kubeconfig and CLAUDE.md are properly copied
- [x] Check file permissions in /home/agent directory
- [x] Verify main container runs as non-root (UID 1001)

🤖 Generated with [Claude Code](https://claude.com/claude-code)