### PR TITLE
Fix: PR check workflow showing false negative for skipped jobs

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -167,13 +167,17 @@ jobs:
                   ref: headSha,
                 });
                 
-                // Find our checks
-                const lintBuild = checkRuns.check_runs.find(run => 
+                // Find our checks - filter all matches, then find non-skipped one
+                const lintBuilds = checkRuns.check_runs.filter(run =>
                   run.name === 'Lint and Build Check'
                 );
-                const dockerBuild = checkRuns.check_runs.find(run => 
+                const dockerBuilds = checkRuns.check_runs.filter(run =>
                   run.name === 'Docker Build Test'
                 );
+
+                // Prefer non-skipped check runs, fallback to first one if all are skipped
+                const lintBuild = lintBuilds.find(run => run.conclusion !== 'skipped') || lintBuilds[0];
+                const dockerBuild = dockerBuilds.find(run => run.conclusion !== 'skipped') || dockerBuilds[0];
                 
                 if (lintBuild && dockerBuild) {
                   console.log(`Lint & Build: ${lintBuild.status}, Docker Build: ${dockerBuild.status}`);


### PR DESCRIPTION
## 🐛 Bug Fix

Fixes issue where PR comments showed ❌ Failed even though checks passed.

## Root Cause

When a PR is created, two workflow runs are triggered:
- `pull_request` event: executes Lint & Build checks (conclusion='success')
- `pull_request_target` event: skips Lint & Build (conclusion='skipped')

The PR comment job queries `github.rest.checks.listForRef()` which returns all check runs for the commit. Using `.find()` to get the first match could return the skipped check from `pull_request_target` instead of the actual executed check from `pull_request`.

## Solution

Modified the check query logic in `.github/workflows/pr-check.yml`:
- Use `.filter()` to get all check runs with the same name
- Then `.find()` to get the first non-skipped one
- Falls back to the first one if all are skipped (defensive)

This ensures we always query the actual executed check run, not the skipped placeholder from the other trigger.

## Changes

- `.github/workflows/pr-check.yml` lines 171-180: Improved check run query logic

## Testing

This PR should demonstrate the fix:
- Lint & Build Check should pass ✅
- Docker Build Test should pass ✅
- PR comment should show ✅ Passed (not ❌ Failed)

## Related

Fixes the false positive failure reported in PR behavior analysis.