### PR TITLE
Replace sandbox T3 editor with code-server

### DIFF
--- a/app/api/projects/route.ts
+++ b/app/api/projects/route.ts
@@ -1,0 +1,314 @@
+import type { Database, Environment, Prisma, Project, Sandbox } from '@prisma/client'
+import { NextResponse } from 'next/server'
+
+import { withAuth } from '@/lib/api-auth'
+import { EnvironmentCategory } from '@/lib/const'
+import { prisma } from '@/lib/db'
+import { getK8sServiceForUser } from '@/lib/k8s/k8s-service-helper'
+import { KubernetesUtils } from '@/lib/k8s/kubernetes-utils'
+import { VERSIONS } from '@/lib/k8s/versions'
+import { logger as baseLogger } from '@/lib/logger'
+import { generateRandomString } from '@/lib/util/common'
+
+const logger = baseLogger.child({ module: 'api/projects' })
+
+/**
+ * Validate project name format
+ * Rules:
+ * - Only letters, numbers, spaces, and hyphens allowed
+ * - Must start with a letter
+ * - Must end with a letter
+ */
+function validateProjectName(name: string): { valid: boolean; error?: string } {
+  // Check if name is empty or only whitespace
+  if (!name || name.trim().length === 0) {
+    return { valid: false, error: 'Project name cannot be empty' }
+  }
+
+  // Check if name contains only allowed characters (letters, numbers, spaces, hyphens)
+  const allowedPattern = /^[a-zA-Z0-9\s-]+$/
+  if (!allowedPattern.test(name)) {
+    return {
+      valid: false,
+      error: 'Project name can only contain letters, numbers, spaces, and hyphens',
+    }
+  }
+
+  // Check if name starts with a letter
+  const trimmedName = name.trim()
+  if (!/^[a-zA-Z]/.test(trimmedName)) {
+    return { valid: false, error: 'Project name must start with a letter' }
+  }
+
+  // Check if name ends with a letter
+  if (!/[a-zA-Z]$/.test(trimmedName)) {
+    return { valid: false, error: 'Project name must end with a letter' }
+  }
+
+  return { valid: true }
+}
+
+type ProjectWithRelations = Project & {
+  databases: Database[]
+  sandboxes: Sandbox[]
+  environments: Environment[]
+}
+
+type GetProjectsResponse = ProjectWithRelations[]
+
+export const GET = withAuth<GetProjectsResponse>(async (req, _context, session) => {
+  // Get query parameters for filtering
+  const { searchParams } = new URL(req.url)
+  const allParam = searchParams.get('all')
+  const keywordParam = searchParams.get('keyword')
+  const createdFromParam = searchParams.get('createdFrom')
+  const createdToParam = searchParams.get('createdTo')
+
+  // Build where clause
+  const whereClause: Prisma.ProjectWhereInput = {
+    userId: session.user.id,
+  }
+
+  // Add keyword filter if provided (searches in both name and description)
+  if (keywordParam) {
+    whereClause.OR = [
+      {
+        name: {
+          contains: keywordParam,
+          mode: 'insensitive',
+        },
+      },
+      {
+        description: {
+          contains: keywordParam,
+          mode: 'insensitive',
+        },
+      },
+    ]
+  }
+
+  // Add createdAt date filters if provided
+  const createdAtFilter: { gte?: Date; lte?: Date } = {}
+  if (createdFromParam) {
+    const createdFrom = new Date(createdFromParam)
+    if (!isNaN(createdFrom.getTime())) {
+      createdAtFilter.gte = createdFrom
+    }
+  }
+  if (createdToParam) {
+    const createdTo = new Date(createdToParam)
+    if (!isNaN(createdTo.getTime())) {
+      createdAtFilter.lte = createdTo
+    }
+  }
+  if (Object.keys(createdAtFilter).length > 0) {
+    whereClause.createdAt = createdAtFilter
+  }
+
+  // Add namespace filter from user's kubeconfig (unless 'all' parameter is provided)
+  if (allParam !== 'true') {
+    try {
+      const k8sService = await getK8sServiceForUser(session.user.id)
+      const namespace = k8sService.getDefaultNamespace()
+      whereClause.sandboxes = {
+        some: {
+          k8sNamespace: namespace,
+        },
+      }
+    } catch {
+      // If user doesn't have kubeconfig configured, log warning but don't fail
+      // Skip namespace filtering and return all projects for the user
+      logger.warn(
+        `User ${session.user.id} does not have KUBECONFIG configured, returning all projects`
+      )
+    }
+  }
+
+  const projects = await prisma.project.findMany({
+    where: whereClause,
+    include: {
+      databases: true,
+      sandboxes: true,
+      environments: true,
+    },
+    orderBy: {
+      updatedAt: 'desc',
+    },
+  })
+
+  logger.info(
+    `Fetched ${projects.length} projects for user ${session.user.id}${allParam === 'true' ? ' (all namespaces)' : ''}`
+  )
+
+  return NextResponse.json(projects)
+})
+
+type PostProjectResponse = { error: string; errorCode?: string; message?: string } | Project
+
+export const POST = withAuth<PostProjectResponse>(async (req, _context, session) => {
+  const body = await req.json()
+  const { name, description, githubRepo, githubBranch } = body
+
+  if (!name || typeof name !== 'string') {
+    return NextResponse.json({ error: 'Project name is required' }, { status: 400 })
+  }
+
+  // Validate project name format
+  const nameValidation = validateProjectName(name)
+  if (!nameValidation.valid) {
+    return NextResponse.json(
+      {
+        error: nameValidation.error || 'Invalid project name format',
+        errorCode: 'INVALID_PROJECT_NAME',
+      },
+      { status: 400 }
+    )
+  }
+
+  logger.info(`Creating project: ${name} for user: ${session.user.id}`)
+
+  // Get K8s service for user - will throw if KUBECONFIG is missing
+  let k8sService
+  let namespace
+  try {
+    k8sService = await getK8sServiceForUser(session.user.id)
+    namespace = k8sService.getDefaultNamespace()
+  } catch (error) {
+    // Check if error is due to missing kubeconfig
+    if (error instanceof Error && error.message.includes('does not have KUBECONFIG configured')) {
+      logger.warn(`Project creation failed - missing kubeconfig for user: ${session.user.id}`)
+      return NextResponse.json(
+        {
+          error: 'Kubeconfig not configured',
+          errorCode: 'KUBECONFIG_MISSING',
+          message: 'Please configure your kubeconfig before creating a project',
+        },
+        { status: 400 }
+      )
+    }
+    // Re-throw other errors
+    throw error
+  }
+
+  // Generate K8s compatible names
+  const k8sProjectName = KubernetesUtils.toK8sProjectName(name)
+  const randomSuffix = KubernetesUtils.generateRandomString()
+  const ttydAuthToken = generateRandomString(24) // 24 chars = ~143 bits entropy for terminal auth
+  const editorPassword = generateRandomString(20) // code-server password
+  const fileBrowserUsername = `fb-${randomSuffix}` // filebrowser username
+  const fileBrowserPassword = generateRandomString(16) // 16 char random password
+  const databaseName = `${k8sProjectName}-${randomSuffix}`
+  const sandboxName = `${k8sProjectName}-${randomSuffix}`
+
+  // Create project with database and sandbox in a transaction
+  const result = await prisma.$transaction(async (tx) => {
+    // 1. Create Project with status CREATING
+    const project = await tx.project.create({
+      data: {
+        name,
+        description,
+        userId: session.user.id,
+        status: 'CREATING',
+        githubRepo: githubRepo || undefined,
+        githubBranch: githubBranch || undefined,
+      },
+    })
+
+    // 2. Create Database record - lockedUntil is null so reconcile job can process immediately
+    const database = await tx.database.create({
+      data: {
+        projectId: project.id,
+        name: databaseName,
+        k8sNamespace: namespace,
+        databaseName: databaseName,
+        status: 'CREATING',
+        lockedUntil: null, // Unlocked - ready for reconcile job to process
+        // Resource configuration from versions
+        storageSize: VERSIONS.STORAGE.DATABASE_SIZE,
+        cpuRequest: VERSIONS.RESOURCES.DATABASE.requests.cpu,
+        cpuLimit: VERSIONS.RESOURCES.DATABASE.limits.cpu,
+        memoryRequest: VERSIONS.RESOURCES.DATABASE.requests.memory,
+        memoryLimit: VERSIONS.RESOURCES.DATABASE.limits.memory,
+      },
+    })
+
+    // 3. Create Sandbox record - lockedUntil is null so reconcile job can process immediately
+    const sandbox = await tx.sandbox.create({
+      data: {
+        projectId: project.id,
+        name: sandboxName,
+        k8sNamespace: namespace,
+        sandboxName: sandboxName,
+        status: 'CREATING',
+        lockedUntil: null, // Unlocked - ready for reconcile job to process
+        // Resource configuration from versions
+        runtimeImage: VERSIONS.RUNTIME_IMAGE,
+        cpuRequest: VERSIONS.RESOURCES.SANDBOX.requests.cpu,
+        cpuLimit: VERSIONS.RESOURCES.SANDBOX.limits.cpu,
+        memoryRequest: VERSIONS.RESOURCES.SANDBOX.requests.memory,
+        memoryLimit: VERSIONS.RESOURCES.SANDBOX.limits.memory,
+      },
+    })
+
+    // 4. Create Environment record for ttyd access token
+    const ttydEnv = await tx.environment.create({
+      data: {
+        projectId: project.id,
+        key: 'TTYD_ACCESS_TOKEN',
+        value: ttydAuthToken,
+        category: EnvironmentCategory.TTYD,
+        isSecret: true, // Mark as secret since it's an access token
+      },
+    })
+
+    // 4b. Create Environment record for editor password
+    const editorPasswordEnv = await tx.environment.create({
+      data: {
+        projectId: project.id,
+        key: 'EDITOR_PASSWORD',
+        value: editorPassword,
+        category: EnvironmentCategory.AUTH,
+        isSecret: true,
+      },
+    })
+
+    // 5. Create Environment records for filebrowser credentials
+    const fileBrowserUsernameEnv = await tx.environment.create({
+      data: {
+        projectId: project.id,
+        key: 'FILE_BROWSER_USERNAME',
+        value: fileBrowserUsername,
+        category: EnvironmentCategory.FILE_BROWSER,
+        isSecret: false,
+      },
+    })
+
+    const fileBrowserPasswordEnv = await tx.environment.create({
+      data: {
+        projectId: project.id,
+        key: 'FILE_BROWSER_PASSWORD',
+        value: fileBrowserPassword,
+        category: EnvironmentCategory.FILE_BROWSER,
+        isSecret: true, // Mark as secret since it's a password
+      },
+    })
+
+    return {
+      project,
+      database,
+      sandbox,
+      ttydEnv,
+      editorPasswordEnv,
+      fileBrowserUsernameEnv,
+      fileBrowserPasswordEnv,
+    }
+  }, {
+    timeout: 20000,
+  })
+
+  logger.info(
+    `Project created: ${result.project.id} with database: ${result.database.id}, sandbox: ${result.sandbox.id}, ttyd env: ${result.ttydEnv.id}, editor password env: ${result.editorPasswordEnv.id}, filebrowser username env: ${result.fileBrowserUsernameEnv.id}, filebrowser password env: ${result.fileBrowserPasswordEnv.id}`
+  )
+
+  return NextResponse.json(result.project)
+})

--- a/app/api/sandbox/[id]/ports/route.ts
+++ b/app/api/sandbox/[id]/ports/route.ts
@@ -1,0 +1,162 @@
+/**
+ * GET/POST/DELETE /api/sandbox/[id]/ports
+ *
+ * Manage custom exposed ports for a sandbox.
+ *
+ * GET    — Returns current exposed ports
+ * POST   — Expose a new port (creates K8s Ingress + Service port)
+ * DELETE — Unexpose a port (removes K8s Ingress + Service port)
+ */
+
+import type { Prisma } from '@prisma/client'
+import { NextResponse } from 'next/server'
+
+import { verifySandboxAccess, withAuth } from '@/lib/api-auth'
+import { prisma } from '@/lib/db'
+import { getK8sServiceForUser } from '@/lib/k8s/k8s-service-helper'
+import { KubernetesUtils } from '@/lib/k8s/kubernetes-utils'
+import { logger as baseLogger } from '@/lib/logger'
+
+const logger = baseLogger.child({ module: 'api/sandbox/[id]/ports' })
+
+interface ExposedPort {
+  port: number
+  url: string
+}
+
+// Built-in ports that cannot be exposed/unexposed by users
+const BUILT_IN_PORTS = [3000, 3773, 7681, 8080]
+
+function getExposedPorts(json: Prisma.JsonValue): ExposedPort[] {
+  if (Array.isArray(json)) return json as unknown as ExposedPort[]
+  return []
+}
+
+export const GET = withAuth(async (_req, context, session) => {
+  const resolvedParams = await context.params
+  const sandboxId = Array.isArray(resolvedParams.id) ? resolvedParams.id[0] : resolvedParams.id
+
+  const sandbox = await verifySandboxAccess(sandboxId, session.user.id)
+  const exposedPorts = getExposedPorts(sandbox.exposedPorts)
+
+  return NextResponse.json({ ports: exposedPorts })
+})
+
+export const POST = withAuth<{ port?: number; url?: string; error?: string }>(async (req, context, session) => {
+  const resolvedParams = await context.params
+  const sandboxId = Array.isArray(resolvedParams.id) ? resolvedParams.id[0] : resolvedParams.id
+
+  try {
+    const body = await req.json()
+    const port = Number(body.port)
+
+    if (!port || port < 1 || port > 65535 || !Number.isInteger(port)) {
+      return NextResponse.json({ error: 'Invalid port number (1-65535)' }, { status: 400 })
+    }
+
+    if (BUILT_IN_PORTS.includes(port)) {
+      return NextResponse.json(
+        { error: `Port ${port} is a built-in port and cannot be exposed manually` },
+        { status: 400 }
+      )
+    }
+
+    const sandbox = await verifySandboxAccess(sandboxId, session.user.id)
+    const existingPorts = getExposedPorts(sandbox.exposedPorts)
+
+    // Check if already exposed
+    if (existingPorts.some((p) => p.port === port)) {
+      const existing = existingPorts.find((p) => p.port === port)!
+      return NextResponse.json({ port: existing.port, url: existing.url })
+    }
+
+    // Get project name for k8s labels
+    const project = await prisma.project.findUnique({
+      where: { id: sandbox.projectId },
+      select: { name: true },
+    })
+
+    if (!project) {
+      return NextResponse.json({ error: 'Project not found' }, { status: 404 })
+    }
+
+    const k8sProjectName = KubernetesUtils.toK8sProjectName(project.name)
+    const k8sService = await getK8sServiceForUser(session.user.id)
+
+    // Expose port in K8s
+    const url = await k8sService.exposePort(
+      sandbox.k8sNamespace,
+      sandbox.sandboxName,
+      k8sProjectName,
+      port
+    )
+
+    // Store in database
+    const updatedPorts: Prisma.JsonArray = [...existingPorts, { port, url }] as unknown as Prisma.JsonArray
+    await prisma.sandbox.update({
+      where: { id: sandboxId },
+      data: { exposedPorts: updatedPorts },
+    })
+
+    logger.info(`Port ${port} exposed for sandbox ${sandboxId}: ${url}`)
+    return NextResponse.json({ port, url })
+  } catch (error) {
+    logger.error(`Failed to expose port for sandbox ${sandboxId}: ${error}`)
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error'
+    return NextResponse.json(
+      { error: `Failed to expose port: ${errorMessage}` },
+      { status: 500 }
+    )
+  }
+})
+
+export const DELETE = withAuth<{ success?: boolean; error?: string }>(async (req, context, session) => {
+  const resolvedParams = await context.params
+  const sandboxId = Array.isArray(resolvedParams.id) ? resolvedParams.id[0] : resolvedParams.id
+
+  try {
+    const body = await req.json()
+    const port = Number(body.port)
+
+    if (!port || port < 1 || port > 65535 || !Number.isInteger(port)) {
+      return NextResponse.json({ error: 'Invalid port number (1-65535)' }, { status: 400 })
+    }
+
+    if (BUILT_IN_PORTS.includes(port)) {
+      return NextResponse.json(
+        { error: `Port ${port} is a built-in port and cannot be removed` },
+        { status: 400 }
+      )
+    }
+
+    const sandbox = await verifySandboxAccess(sandboxId, session.user.id)
+    const existingPorts = getExposedPorts(sandbox.exposedPorts)
+
+    // Check if port is actually exposed
+    if (!existingPorts.some((p) => p.port === port)) {
+      return NextResponse.json({ error: `Port ${port} is not exposed` }, { status: 404 })
+    }
+
+    const k8sService = await getK8sServiceForUser(session.user.id)
+
+    // Unexpose port in K8s
+    await k8sService.unexposePort(sandbox.k8sNamespace, sandbox.sandboxName, port)
+
+    // Remove from database
+    const updatedPorts: Prisma.JsonArray = existingPorts.filter((p) => p.port !== port) as unknown as Prisma.JsonArray
+    await prisma.sandbox.update({
+      where: { id: sandboxId },
+      data: { exposedPorts: updatedPorts },
+    })
+
+    logger.info(`Port ${port} unexposed for sandbox ${sandboxId}`)
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    logger.error(`Failed to unexpose port for sandbox ${sandboxId}: ${error}`)
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error'
+    return NextResponse.json(
+      { error: `Failed to unexpose port: ${errorMessage}` },
+      { status: 500 }
+    )
+  }
+})

--- a/components/editor/editor-panel-host.tsx
+++ b/components/editor/editor-panel-host.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import type { Sandbox } from '@prisma/client';
+
+interface EditorPanelHostProps {
+  sandbox: Sandbox | undefined;
+}
+
+export function EditorPanelHost({ sandbox }: EditorPanelHostProps) {
+  if (!sandbox?.editorUrl) {
+    return (
+      <div className="flex h-full items-center justify-center bg-background text-sm text-muted-foreground">
+        Editor is not available yet.
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-background">
+      <iframe
+        src={sandbox.editorUrl}
+        className="h-full w-full border-0"
+        title="Editor"
+      />
+    </div>
+  );
+}

--- a/components/terminal/terminal-container.tsx
+++ b/components/terminal/terminal-container.tsx
@@ -13,7 +13,7 @@
 
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { Prisma } from '@prisma/client';
 
 import { type Tab } from './toolbar/terminal-tabs';
@@ -50,13 +50,40 @@ export interface TerminalContainerProps {
 // Component
 // ============================================================================
 
+// Generate a stable tab ID that won't collide
+function generateTabId(): string {
+  return `tab-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+// localStorage key for persisting tab state per project
+function getStorageKey(projectId: string): string {
+  return `terminal-tabs-${projectId}`;
+}
+
 export function TerminalContainer({ project, sandbox, isVisible = true }: TerminalContainerProps) {
   // =========================================================================
-  // Tab State Management
+  // Tab State Management (persisted in localStorage for refresh survival)
   // =========================================================================
 
-  const [tabs, setTabs] = useState<Tab[]>([{ id: '1', name: 'Terminal 1' }]);
-  const [activeTabId, setActiveTabId] = useState('1');
+  const [tabs, setTabs] = useState<Tab[]>(() => {
+    if (typeof window === 'undefined') return [{ id: generateTabId(), name: 'Terminal 1' }];
+    try {
+      const stored = localStorage.getItem(getStorageKey(project.id));
+      if (stored) {
+        const parsed = JSON.parse(stored) as Tab[];
+        if (Array.isArray(parsed) && parsed.length > 0) return parsed;
+      }
+    } catch {}
+    return [{ id: generateTabId(), name: 'Terminal 1' }];
+  });
+  const [activeTabId, setActiveTabId] = useState(() => tabs[0]?.id ?? '');
+
+  // Persist tabs to localStorage on change
+  useEffect(() => {
+    try {
+      localStorage.setItem(getStorageKey(project.id), JSON.stringify(tabs));
+    } catch {}
+  }, [tabs, project.id]);
 
   // =========================================================================
   // Extract FileBrowser Credentials
@@ -74,6 +101,9 @@ export function TerminalContainer({ project, sandbox, isVisible = true }: Termin
     return undefined;
   })();
 
+  const editorPassword = project.environments?.find((env) => env.key === 'EDITOR_PASSWORD')
+    ?.value;
+
   // =========================================================================
   // Tab Operations
   // =========================================================================
@@ -82,13 +112,12 @@ export function TerminalContainer({ project, sandbox, isVisible = true }: Termin
    * Create and activate a new terminal tab
    */
   const handleTabAdd = () => {
-    const newId = Date.now().toString();
     const newTab: Tab = {
-      id: newId,
+      id: generateTabId(),
       name: `Terminal ${tabs.length + 1}`,
     };
     setTabs([...tabs, newTab]);
-    setActiveTabId(newId);
+    setActiveTabId(newTab.id);
   };
 
   /**
@@ -122,6 +151,7 @@ export function TerminalContainer({ project, sandbox, isVisible = true }: Termin
     <div className="flex flex-col flex-1 min-h-0 bg-background">
       {/* Toolbar with tabs and operations */}
       <TerminalToolbar
+        project={project}
         sandbox={sandbox}
         tabs={tabs}
         activeTabId={activeTabId}
@@ -129,6 +159,7 @@ export function TerminalContainer({ project, sandbox, isVisible = true }: Termin
         onTabClose={handleTabClose}
         onTabAdd={handleTabAdd}
         fileBrowserCredentials={fileBrowserCredentials}
+        editorPassword={editorPassword}
       />
 
       {/* Terminal display area with tab switching */}
@@ -154,6 +185,7 @@ export function TerminalContainer({ project, sandbox, isVisible = true }: Termin
               ttydUrl={sandbox?.ttydUrl}
               status={sandbox?.status ?? 'CREATING'}
               tabId={tab.id}
+              sessionId={tab.id}
               fileBrowserUrl={sandbox?.fileBrowserUrl}
               fileBrowserUsername={fileBrowserCredentials?.username}
               fileBrowserPassword={fileBrowserCredentials?.password}

--- a/components/terminal/toolbar/network-dialog.tsx
+++ b/components/terminal/toolbar/network-dialog.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useState } from 'react';
-import { MdContentCopy, MdVisibility, MdVisibilityOff } from 'react-icons/md';
+import { useCallback, useEffect, useState } from 'react';
+import { MdClose, MdContentCopy, MdVisibility, MdVisibilityOff } from 'react-icons/md';
 
 import {
   Dialog,
@@ -11,26 +11,22 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 
+import type { NetworkEndpoint } from './network-endpoints';
+
 // ============================================================================
 // Types
 // ============================================================================
 
-export interface NetworkEndpoint {
-  domain: string | null | undefined;
+interface ExposedPort {
   port: number;
-  protocol: string;
-  label: string;
-  hasCredentials?: boolean;
+  url: string;
 }
 
 export interface NetworkDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   endpoints: NetworkEndpoint[];
-  fileBrowserCredentials?: {
-    username: string;
-    password: string;
-  };
+  sandboxId?: string;
 }
 
 // ============================================================================
@@ -41,10 +37,33 @@ export function NetworkDialog({
   open,
   onOpenChange,
   endpoints,
-  fileBrowserCredentials,
+  sandboxId,
 }: NetworkDialogProps) {
-  const [showPassword, setShowPassword] = useState(false);
   const [copiedField, setCopiedField] = useState<string | null>(null);
+  const [visibleSecrets, setVisibleSecrets] = useState<Record<string, boolean>>({});
+  const [portInput, setPortInput] = useState('');
+  const [exposedPorts, setExposedPorts] = useState<ExposedPort[]>([]);
+  const [isExposing, setIsExposing] = useState(false);
+  const [portError, setPortError] = useState<string | null>(null);
+
+  const fetchExposedPorts = useCallback(async () => {
+    if (!sandboxId) return;
+    try {
+      const res = await fetch(`/api/sandbox/${sandboxId}/ports`);
+      if (res.ok) {
+        const data = await res.json();
+        setExposedPorts(data.ports || []);
+      }
+    } catch {
+      // silently fail
+    }
+  }, [sandboxId]);
+
+  useEffect(() => {
+    if (open && sandboxId) {
+      fetchExposedPorts();
+    }
+  }, [open, sandboxId, fetchExposedPorts]);
 
   const copyToClipboard = async (text: string, field: string) => {
     try {
@@ -53,6 +72,65 @@ export function NetworkDialog({
       setTimeout(() => setCopiedField(null), 2000);
     } catch (err) {
       console.error('Failed to copy:', err);
+    }
+  };
+
+  const handleExposePort = async () => {
+    const port = parseInt(portInput, 10);
+    if (!port || port < 1 || port > 65535) {
+      setPortError('Enter a valid port (1-65535)');
+      return;
+    }
+
+    if ([3000, 3773, 7681, 8080].includes(port)) {
+      setPortError('This is a built-in port');
+      return;
+    }
+
+    if (exposedPorts.some((p) => p.port === port)) {
+      setPortError('Port already exposed');
+      return;
+    }
+
+    setPortError(null);
+    setIsExposing(true);
+
+    try {
+      const res = await fetch(`/api/sandbox/${sandboxId}/ports`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ port }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        setPortError(data.error || 'Failed to expose port');
+        return;
+      }
+
+      const data = await res.json();
+      setExposedPorts((prev) => [...prev, { port: data.port, url: data.url }]);
+      setPortInput('');
+    } catch {
+      setPortError('Network error');
+    } finally {
+      setIsExposing(false);
+    }
+  };
+
+  const handleUnexposePort = async (port: number) => {
+    try {
+      const res = await fetch(`/api/sandbox/${sandboxId}/ports`, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ port }),
+      });
+
+      if (res.ok) {
+        setExposedPorts((prev) => prev.filter((p) => p.port !== port));
+      }
+    } catch {
+      // silently fail
     }
   };
 
@@ -66,6 +144,7 @@ export function NetworkDialog({
           </DialogDescription>
         </DialogHeader>
         <div className="space-y-2.5 mt-5">
+          {/* Built-in endpoints */}
           {endpoints.map((endpoint, index) => (
             <div
               key={index}
@@ -81,7 +160,7 @@ export function NetworkDialog({
                 <span className="text-xs text-[#858585] font-mono">{endpoint.protocol}</span>
               </div>
               <a
-                href={endpoint.domain || undefined}
+                href={endpoint.domain}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-xs text-[#3794ff] hover:text-[#4fc1ff] break-all underline underline-offset-2 hover:underline-offset-4 transition-all"
@@ -89,68 +168,127 @@ export function NetworkDialog({
                 {endpoint.domain}
               </a>
 
-              {/* Show credentials for File Browser */}
-              {endpoint.hasCredentials && fileBrowserCredentials && (
+              {endpoint.credentials && endpoint.credentials.length > 0 && (
                 <div className="mt-3 pt-3 border-t border-[#3e3e42] space-y-2">
                   <div className="text-xs text-gray-400 mb-1.5">Login Credentials:</div>
+                  {endpoint.credentials.map((credential) => {
+                    const isSecret = Boolean(credential.secret);
+                    const isVisible = visibleSecrets[credential.id] ?? false;
 
-                  {/* Username */}
-                  <div className="flex items-center gap-2 bg-[#252526] rounded p-2 border border-[#3e3e42]">
-                    <div className="flex-1 min-w-0">
-                      <div className="text-[10px] text-gray-500 mb-0.5">Username</div>
-                      <code className="text-xs text-blue-400 break-all">
-                        {fileBrowserCredentials.username}
-                      </code>
-                    </div>
-                    <button
-                      onClick={() => copyToClipboard(fileBrowserCredentials.username, 'username')}
-                      className="p-1.5 hover:bg-[#37373d] rounded transition-colors shrink-0"
-                      title="Copy username"
-                    >
-                      {copiedField === 'username' ? (
-                        <span className="text-xs text-green-400">✓</span>
-                      ) : (
-                        <MdContentCopy className="h-3.5 w-3.5 text-gray-400" />
-                      )}
-                    </button>
-                  </div>
-
-                  {/* Password */}
-                  <div className="flex items-center gap-2 bg-[#252526] rounded p-2 border border-[#3e3e42]">
-                    <div className="flex-1 min-w-0">
-                      <div className="text-[10px] text-gray-500 mb-0.5">Password</div>
-                      <code className="text-xs text-blue-400 break-all">
-                        {showPassword ? fileBrowserCredentials.password : '••••••••••••••••'}
-                      </code>
-                    </div>
-                    <button
-                      onClick={() => setShowPassword(!showPassword)}
-                      className="p-1.5 hover:bg-[#37373d] rounded transition-colors shrink-0"
-                      title={showPassword ? 'Hide password' : 'Show password'}
-                    >
-                      {showPassword ? (
-                        <MdVisibilityOff className="h-3.5 w-3.5 text-gray-400" />
-                      ) : (
-                        <MdVisibility className="h-3.5 w-3.5 text-gray-400" />
-                      )}
-                    </button>
-                    <button
-                      onClick={() => copyToClipboard(fileBrowserCredentials.password, 'password')}
-                      className="p-1.5 hover:bg-[#37373d] rounded transition-colors shrink-0"
-                      title="Copy password"
-                    >
-                      {copiedField === 'password' ? (
-                        <span className="text-xs text-green-400">✓</span>
-                      ) : (
-                        <MdContentCopy className="h-3.5 w-3.5 text-gray-400" />
-                      )}
-                    </button>
-                  </div>
+                    return (
+                      <div
+                        key={credential.id}
+                        className="flex items-center gap-2 bg-[#252526] rounded p-2 border border-[#3e3e42]"
+                      >
+                        <div className="flex-1 min-w-0">
+                          <div className="text-[10px] text-gray-500 mb-0.5">{credential.label}</div>
+                          <code className="text-xs text-blue-400 break-all">
+                            {isSecret && !isVisible ? '••••••••••••••••' : credential.value}
+                          </code>
+                        </div>
+                        {isSecret && (
+                          <button
+                            onClick={() =>
+                              setVisibleSecrets((current) => ({
+                                ...current,
+                                [credential.id]: !isVisible,
+                              }))
+                            }
+                            className="p-1.5 hover:bg-[#37373d] rounded transition-colors shrink-0"
+                            title={isVisible ? `Hide ${credential.label.toLowerCase()}` : `Show ${credential.label.toLowerCase()}`}
+                          >
+                            {isVisible ? (
+                              <MdVisibilityOff className="h-3.5 w-3.5 text-gray-400" />
+                            ) : (
+                              <MdVisibility className="h-3.5 w-3.5 text-gray-400" />
+                            )}
+                          </button>
+                        )}
+                        <button
+                          onClick={() => copyToClipboard(credential.value, credential.id)}
+                          className="p-1.5 hover:bg-[#37373d] rounded transition-colors shrink-0"
+                          title={`Copy ${credential.label.toLowerCase()}`}
+                        >
+                          {copiedField === credential.id ? (
+                            <span className="text-xs text-green-400">✓</span>
+                          ) : (
+                            <MdContentCopy className="h-3.5 w-3.5 text-gray-400" />
+                          )}
+                        </button>
+                      </div>
+                    );
+                  })}
                 </div>
               )}
             </div>
           ))}
+
+          {/* Custom exposed ports */}
+          {exposedPorts.map((ep) => (
+            <div
+              key={ep.port}
+              className="p-3.5 bg-[#1e1e1e] rounded-lg border border-[#3e3e42] hover:border-[#4e4e52] transition-colors"
+            >
+              <div className="flex items-center justify-between mb-2.5">
+                <div className="flex items-center gap-2.5">
+                  <span className="text-sm font-medium text-white">Port {ep.port}</span>
+                  <span className="text-xs px-2 py-0.5 rounded bg-[#1a3a2a] text-emerald-400 border border-emerald-800">
+                    Custom
+                  </span>
+                </div>
+                <button
+                  onClick={() => handleUnexposePort(ep.port)}
+                  className="p-1 hover:bg-[#37373d] rounded transition-colors"
+                  title="Remove port"
+                >
+                  <MdClose className="h-4 w-4 text-gray-400 hover:text-red-400" />
+                </button>
+              </div>
+              <a
+                href={ep.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-xs text-[#3794ff] hover:text-[#4fc1ff] break-all underline underline-offset-2 hover:underline-offset-4 transition-all"
+              >
+                {ep.url}
+              </a>
+            </div>
+          ))}
         </div>
+
+        {/* Expose Port form */}
+        {sandboxId && (
+          <div className="mt-4 pt-4 border-t border-[#3e3e42]">
+            <div className="text-xs text-gray-400 mb-2">Expose a custom port</div>
+            <div className="flex gap-2">
+              <input
+                type="number"
+                value={portInput}
+                onChange={(e) => {
+                  setPortInput(e.target.value);
+                  setPortError(null);
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && !isExposing) handleExposePort();
+                }}
+                placeholder="e.g. 5173"
+                min={1}
+                max={65535}
+                className="flex-1 bg-[#1e1e1e] border border-[#3e3e42] rounded px-3 py-1.5 text-sm text-white placeholder-gray-600 focus:outline-none focus:border-[#3794ff] [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+              />
+              <button
+                onClick={handleExposePort}
+                disabled={isExposing || !portInput}
+                className="px-3 py-1.5 bg-[#3794ff] hover:bg-[#2b7cd8] disabled:opacity-50 disabled:cursor-not-allowed rounded text-sm text-white font-medium transition-colors"
+              >
+                {isExposing ? 'Exposing...' : 'Expose'}
+              </button>
+            </div>
+            {portError && (
+              <div className="text-xs text-red-400 mt-1.5">{portError}</div>
+            )}
+          </div>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/components/terminal/toolbar/network-endpoints.test.ts
+++ b/components/terminal/toolbar/network-endpoints.test.ts
@@ -1,0 +1,111 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+let buildNetworkEndpoints:
+  | ((
+      input: {
+        sandbox?: {
+          publicUrl?: string | null
+          ttydUrl?: string | null
+          fileBrowserUrl?: string | null
+          editorUrl?: string | null
+        }
+        fileBrowserCredentials?: {
+          username: string
+          password: string
+        }
+        editorPassword?: string
+      }
+    ) => Array<{
+      label: string
+      port: number
+      domain: string
+      credentials?: Array<{
+        id: string
+        label: string
+        value: string
+        secret?: boolean
+      }>
+    }>)
+  | undefined
+
+try {
+  ;({ buildNetworkEndpoints } = await import('./network-endpoints.ts'))
+} catch {
+  buildNetworkEndpoints = undefined
+}
+
+test('buildNetworkEndpoints includes editor and file browser credentials', () => {
+  assert.equal(typeof buildNetworkEndpoints, 'function')
+
+  const endpoints = buildNetworkEndpoints?.({
+    sandbox: {
+      publicUrl: 'https://demo-app.example.com',
+      ttydUrl: 'https://demo-ttyd.example.com?arg=ttyd-secret',
+      fileBrowserUrl: 'https://demo-filebrowser.example.com',
+      editorUrl: 'https://demo-editor.example.com',
+    },
+    fileBrowserCredentials: {
+      username: 'fb-user',
+      password: 'fb-secret',
+    },
+    editorPassword: 'editor-secret',
+  })
+
+  assert.deepEqual(endpoints, [
+    {
+      label: 'Application',
+      port: 3000,
+      domain: 'https://demo-app.example.com',
+      protocol: 'HTTPS',
+    },
+    {
+      label: 'Terminal',
+      port: 7681,
+      domain: 'https://demo-ttyd.example.com?arg=ttyd-secret',
+      protocol: 'HTTPS',
+    },
+    {
+      label: 'File Browser',
+      port: 8080,
+      domain: 'https://demo-filebrowser.example.com',
+      protocol: 'HTTPS',
+      credentials: [
+        { id: 'file-browser-username', label: 'Username', value: 'fb-user' },
+        { id: 'file-browser-password', label: 'Password', value: 'fb-secret', secret: true },
+      ],
+    },
+    {
+      label: 'Editor',
+      port: 3773,
+      domain: 'https://demo-editor.example.com',
+      protocol: 'HTTPS',
+      credentials: [
+        { id: 'editor-password', label: 'Password', value: 'editor-secret', secret: true },
+      ],
+    },
+  ])
+})
+
+test('buildNetworkEndpoints omits services that do not have URLs', () => {
+  assert.equal(typeof buildNetworkEndpoints, 'function')
+
+  const endpoints = buildNetworkEndpoints?.({
+    sandbox: {
+      publicUrl: null,
+      ttydUrl: undefined,
+      fileBrowserUrl: 'https://demo-filebrowser.example.com',
+      editorUrl: null,
+    },
+  })
+
+  assert.deepEqual(endpoints, [
+    {
+      label: 'File Browser',
+      port: 8080,
+      domain: 'https://demo-filebrowser.example.com',
+      protocol: 'HTTPS',
+      credentials: undefined,
+    },
+  ])
+})

--- a/components/terminal/toolbar/network-endpoints.ts
+++ b/components/terminal/toolbar/network-endpoints.ts
@@ -1,0 +1,96 @@
+export interface NetworkCredentialField {
+  id: string
+  label: string
+  value: string
+  secret?: boolean
+}
+
+export interface NetworkEndpoint {
+  domain: string
+  port: number
+  protocol: string
+  label: string
+  credentials?: NetworkCredentialField[]
+}
+
+interface BuildNetworkEndpointsInput {
+  sandbox?: {
+    publicUrl?: string | null
+    ttydUrl?: string | null
+    fileBrowserUrl?: string | null
+    editorUrl?: string | null
+  }
+  fileBrowserCredentials?: {
+    username: string
+    password: string
+  }
+  editorPassword?: string
+}
+
+export function buildNetworkEndpoints({
+  sandbox,
+  fileBrowserCredentials,
+  editorPassword,
+}: BuildNetworkEndpointsInput): NetworkEndpoint[] {
+  const endpoints: Array<NetworkEndpoint | null> = [
+    sandbox?.publicUrl
+      ? {
+          domain: sandbox.publicUrl,
+          port: 3000,
+          protocol: 'HTTPS',
+          label: 'Application',
+        }
+      : null,
+    sandbox?.ttydUrl
+      ? {
+          domain: sandbox.ttydUrl,
+          port: 7681,
+          protocol: 'HTTPS',
+          label: 'Terminal',
+        }
+      : null,
+    sandbox?.fileBrowserUrl
+      ? {
+          domain: sandbox.fileBrowserUrl,
+          port: 8080,
+          protocol: 'HTTPS',
+          label: 'File Browser',
+          credentials: fileBrowserCredentials
+            ? [
+                {
+                  id: 'file-browser-username',
+                  label: 'Username',
+                  value: fileBrowserCredentials.username,
+                },
+                {
+                  id: 'file-browser-password',
+                  label: 'Password',
+                  value: fileBrowserCredentials.password,
+                  secret: true,
+                },
+              ]
+            : undefined,
+        }
+      : null,
+    sandbox?.editorUrl
+      ? {
+          domain: sandbox.editorUrl,
+          port: 3773,
+          protocol: 'HTTPS',
+          label: 'Editor',
+          credentials: editorPassword
+            ? [
+                {
+                  id: 'editor-password',
+                  label: 'Password',
+                  value: editorPassword,
+                  secret: true,
+                },
+              ]
+            : undefined,
+        }
+      : null,
+  ]
+
+  return endpoints.filter((endpoint): endpoint is NetworkEndpoint => endpoint !== null)
+}

--- a/components/terminal/toolbar/toolbar.tsx
+++ b/components/terminal/toolbar/toolbar.tsx
@@ -7,16 +7,27 @@
 'use client';
 
 import { useState } from 'react';
-import { MdLan } from 'react-icons/md';
+import { MdLan, MdPsychology } from 'react-icons/md';
 import type { Prisma } from '@prisma/client';
+import { useRouter } from 'next/navigation';
 
 import { AppRunner } from './app-runner';
 import { NetworkDialog } from './network-dialog';
+import { buildNetworkEndpoints } from './network-endpoints';
 import { type Tab,TerminalTabs } from './terminal-tabs';
+
+type Project = Prisma.ProjectGetPayload<{
+  include: {
+    sandboxes: true;
+    databases: true;
+  };
+}>;
 
 type Sandbox = Prisma.SandboxGetPayload<object>;
 
 export interface TerminalToolbarProps {
+  /** Project data */
+  project: Project;
   /** Sandbox data */
   sandbox: Sandbox | undefined;
   /** Terminal tabs */
@@ -34,12 +45,15 @@ export interface TerminalToolbarProps {
     username: string;
     password: string;
   };
+  /** Editor password (optional) */
+  editorPassword?: string;
 }
 
 /**
  * Terminal toolbar with tabs and operations
  */
 export function TerminalToolbar({
+  project,
   sandbox,
   tabs,
   activeTabId,
@@ -47,24 +61,16 @@ export function TerminalToolbar({
   onTabClose,
   onTabAdd,
   fileBrowserCredentials,
+  editorPassword,
 }: TerminalToolbarProps) {
   const [showNetworkDialog, setShowNetworkDialog] = useState(false);
+  const router = useRouter();
 
-  // Build network endpoints list, filtering out any without URLs
-  const allEndpoints = [
-    { domain: sandbox?.publicUrl, port: 3000, protocol: 'HTTPS', label: 'Application' },
-    { domain: sandbox?.ttydUrl, port: 7681, protocol: 'HTTPS', label: 'Terminal' },
-    {
-      domain: sandbox?.fileBrowserUrl,
-      port: 8080,
-      protocol: 'HTTPS',
-      label: 'File Browser',
-      hasCredentials: true,
-    },
-  ];
-
-  // Only show endpoints that have a valid domain URL
-  const networkEndpoints = allEndpoints.filter((endpoint) => endpoint.domain);
+  const networkEndpoints = buildNetworkEndpoints({
+    sandbox,
+    fileBrowserCredentials,
+    editorPassword,
+  });
 
   return (
     <>
@@ -81,6 +87,16 @@ export function TerminalToolbar({
         {/* Action Buttons */}
         <div className="flex items-center gap-2">
           <AppRunner sandbox={sandbox} />
+
+          {/* Editor Button - navigates to embedded VS Code server */}
+          <button
+            onClick={() => router.push(`/projects/${project.id}/brain`)}
+            className="px-2 py-1 text-xs text-foreground font-semibold hover:text-white hover:bg-zinc-800 rounded transition-colors flex items-center gap-1"
+            title="Open Editor"
+          >
+            <MdPsychology className="h-3.5 w-3.5 text-purple-500" />
+            <span>Editor</span>
+          </button>
 
           {/* Network Button */}
           <button
@@ -99,7 +115,7 @@ export function TerminalToolbar({
         open={showNetworkDialog}
         onOpenChange={setShowNetworkDialog}
         endpoints={networkEndpoints}
-        fileBrowserCredentials={fileBrowserCredentials}
+        sandboxId={sandbox?.id}
       />
     </>
   );

--- a/lib/events/sandbox/sandboxListener.ts
+++ b/lib/events/sandbox/sandboxListener.ts
@@ -1,4 +1,4 @@
-import { triggerRunnableTasksForProject } from '@/lib/jobs/project-task'
+import { prisma } from '@/lib/db'
 import { getK8sServiceForUser } from '@/lib/k8s/k8s-service-helper'
 import { logger as baseLogger } from '@/lib/logger'
 import { getProjectEnvironments } from '@/lib/repo/environment'
@@ -53,7 +53,7 @@ async function handleCreateSandbox(payload: SandboxEventPayload): Promise<void> 
     )
 
     logger.info(
-      `Sandbox ${sandbox.id} created in Kubernetes: ${sandboxInfo.publicUrl}, ${sandboxInfo.ttydUrl}, ${sandboxInfo.fileBrowserUrl}`
+      `Sandbox ${sandbox.id} created in Kubernetes: ${sandboxInfo.publicUrl}, ${sandboxInfo.ttydUrl}, ${sandboxInfo.fileBrowserUrl}, ${sandboxInfo.editorUrl}`
     )
 
     // Update sandbox with URLs
@@ -61,7 +61,8 @@ async function handleCreateSandbox(payload: SandboxEventPayload): Promise<void> 
       sandbox.id,
       sandboxInfo.publicUrl,
       sandboxInfo.ttydUrl,
-      sandboxInfo.fileBrowserUrl
+      sandboxInfo.fileBrowserUrl,
+      sandboxInfo.editorUrl
     )
 
     // Change status to STARTING
@@ -113,12 +114,18 @@ async function handleStartSandbox(payload: SandboxEventPayload): Promise<void> {
 
     logger.info(`Sandbox ${sandbox.id} K8s status: ${k8sStatus}`)
 
-    // If status is RUNNING, update database
+    // If status is RUNNING, update database and trigger repo clone if needed
     if (k8sStatus === 'RUNNING') {
       await updateSandboxStatus(sandbox.id, 'RUNNING')
       await projectStatusReconcile(project.id)
       logger.info(`Sandbox ${sandbox.id} is now RUNNING`)
-      void triggerImportOnSandboxRunning(project.id)
+
+      // Clone GitHub repo if configured (fire and forget - don't block status)
+      if (project.githubRepo) {
+        cloneGitHubRepo(user.id, sandbox, project).catch((err) => {
+          logger.error(`Background clone failed for sandbox ${sandbox.id}: ${err}`)
+        })
+      }
     } else {
       logger.info(`Sandbox ${sandbox.id} is still starting (K8s status: ${k8sStatus})`)
       // Keep status as STARTING, may need to poll again
@@ -308,7 +315,6 @@ async function handleUpdateSandbox(payload: SandboxEventPayload): Promise<void> 
       await updateSandboxStatus(sandbox.id, 'RUNNING')
       await projectStatusReconcile(project.id)
       logger.info(`Sandbox ${sandbox.id} is now RUNNING`)
-      void triggerImportOnSandboxRunning(project.id)
     } else if (k8sStatus === 'STARTING') {
       // Pod is restarting due to env var changes - change status to STARTING
       await updateSandboxStatus(sandbox.id, 'STARTING')
@@ -336,15 +342,70 @@ async function handleUpdateSandbox(payload: SandboxEventPayload): Promise<void> 
 }
 
 /**
+ * Clone a GitHub repository into the sandbox after it becomes RUNNING.
+ * Uses the user's stored OAuth token for authentication.
+ * Clones into ~/projectName (e.g. /home/fulling/mono for project "mono").
+ */
+async function cloneGitHubRepo(
+  userId: string,
+  sandbox: { id: string; k8sNamespace: string; sandboxName: string },
+  project: { id: string; name: string; githubRepo: string | null; githubBranch: string | null }
+): Promise<void> {
+  if (!project.githubRepo) return
+
+  logger.info(`Cloning GitHub repo ${project.githubRepo} into sandbox ${sandbox.id}`)
+
+  // Get user's GitHub OAuth token
+  const githubIdentity = await prisma.userIdentity.findFirst({
+    where: { userId, provider: 'GITHUB' },
+  })
+
+  if (!githubIdentity) {
+    logger.warn(`No GitHub identity found for user ${userId}, skipping clone`)
+    return
+  }
+
+  const metadata = githubIdentity.metadata as { token?: string }
+  if (!metadata.token) {
+    logger.warn(`No GitHub token found for user ${userId}, skipping clone`)
+    return
+  }
+
+  const branch = project.githubBranch || 'main'
+  const repoFullName = project.githubRepo
+  const authUrl = `https://x-access-token:${metadata.token}@github.com/${repoFullName}.git`
+
+  // Use the project name as the clone directory (sanitize for filesystem safety)
+  const cloneDir = project.name.replace(/[^a-zA-Z0-9._-]/g, '-')
+  const clonePath = `/home/fulling/${cloneDir}`
+
+  try {
+    const k8sService = await getK8sServiceForUser(userId)
+
+    const cloneCommand = [
+      'set -e',
+      `rm -rf '${clonePath}'`,
+      `GIT_TERMINAL_PROMPT=0 git clone --depth 1 --branch '${branch.replace(/'/g, "'\\''")}' '${authUrl.replace(/'/g, "'\\''")}' '${clonePath}'`,
+      `cd '${clonePath}' && git remote set-url origin "https://github.com/${repoFullName}.git"`,
+    ].join(' && ')
+
+    await k8sService.execCommandInBackground(
+      sandbox.k8sNamespace,
+      sandbox.sandboxName,
+      cloneCommand
+    )
+
+    logger.info(`Git clone initiated for sandbox ${sandbox.id} (repo: ${repoFullName}, branch: ${branch}, path: ${clonePath})`)
+  } catch (error) {
+    logger.error(`Failed to clone repo into sandbox ${sandbox.id}: ${error}`)
+  }
+}
+
+/**
  * Register all sandbox event listeners
  * Call this function once during application startup
  */
 export function registerSandboxListeners(): void {
-  if (globalThis.__sandboxListenersRegistered) {
-    logger.info('Sandbox event listeners already registered, skipping')
-    return
-  }
-
   logger.info('Registering sandbox event listeners')
   on(Events.UpdateSandbox, handleUpdateSandbox)
   on(Events.CreateSandbox, handleCreateSandbox)
@@ -352,21 +413,8 @@ export function registerSandboxListeners(): void {
   on(Events.StopSandbox, handleStopSandbox)
   on(Events.DeleteSandbox, handleDeleteSandbox)
 
-  globalThis.__sandboxListenersRegistered = true
   logger.info('✅ Sandbox event listeners registered')
 }
 
 // Auto-register listeners when module is imported
 registerSandboxListeners()
-
-async function triggerImportOnSandboxRunning(projectId: string): Promise<void> {
-  try {
-    await triggerRunnableTasksForProject(projectId)
-  } catch (error) {
-    logger.error(`Failed to trigger project tasks for ${projectId}: ${error}`)
-  }
-}
-
-declare global {
-  var __sandboxListenersRegistered: boolean | undefined
-}

--- a/lib/k8s/sandbox-endpoints.test.ts
+++ b/lib/k8s/sandbox-endpoints.test.ts
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+let buildSandboxUrls:
+  | ((
+      input: {
+        sandboxName: string
+        ingressDomain: string
+        ttydAccessToken?: string
+      }
+    ) => {
+      publicUrl: string
+      ttydUrl: string
+      fileBrowserUrl: string
+      editorUrl: string
+    })
+  | undefined
+
+try {
+  ;({ buildSandboxUrls } = await import('./sandbox-endpoints.ts'))
+} catch {
+  buildSandboxUrls = undefined
+}
+
+test('buildSandboxUrls returns editor endpoint and ttyd tokenized URL', () => {
+  assert.equal(typeof buildSandboxUrls, 'function')
+
+  const urls = buildSandboxUrls?.({
+    sandboxName: 'demo-sandbox',
+    ingressDomain: 'example.com',
+    ttydAccessToken: 'terminal-secret',
+  })
+
+  assert.deepEqual(urls, {
+    publicUrl: 'https://demo-sandbox-app.example.com',
+    ttydUrl: 'https://demo-sandbox-ttyd.example.com?arg=terminal-secret',
+    fileBrowserUrl: 'https://demo-sandbox-filebrowser.example.com',
+    editorUrl: 'https://demo-sandbox-editor.example.com',
+  })
+})
+
+test('buildSandboxUrls omits ttyd query when no token is available', () => {
+  assert.equal(typeof buildSandboxUrls, 'function')
+
+  const urls = buildSandboxUrls?.({
+    sandboxName: 'demo-sandbox',
+    ingressDomain: 'example.com',
+  })
+
+  assert.equal(urls?.ttydUrl, 'https://demo-sandbox-ttyd.example.com')
+  assert.equal(urls?.editorUrl, 'https://demo-sandbox-editor.example.com')
+})

--- a/lib/k8s/sandbox-endpoints.ts
+++ b/lib/k8s/sandbox-endpoints.ts
@@ -1,0 +1,29 @@
+export interface BuildSandboxUrlsInput {
+  sandboxName: string
+  ingressDomain: string
+  ttydAccessToken?: string
+}
+
+export interface SandboxUrls {
+  publicUrl: string
+  ttydUrl: string
+  fileBrowserUrl: string
+  editorUrl: string
+}
+
+export function buildSandboxUrls({
+  sandboxName,
+  ingressDomain,
+  ttydAccessToken,
+}: BuildSandboxUrlsInput): SandboxUrls {
+  const publicUrl = `https://${sandboxName}-app.${ingressDomain}`
+  const ttydBaseUrl = `https://${sandboxName}-ttyd.${ingressDomain}`
+  const ttydUrl = ttydAccessToken ? `${ttydBaseUrl}?arg=${ttydAccessToken}` : ttydBaseUrl
+
+  return {
+    publicUrl,
+    ttydUrl,
+    fileBrowserUrl: `https://${sandboxName}-filebrowser.${ingressDomain}`,
+    editorUrl: `https://${sandboxName}-editor.${ingressDomain}`,
+  }
+}

--- a/lib/k8s/sandbox-manager.ts
+++ b/lib/k8s/sandbox-manager.ts
@@ -5,6 +5,7 @@ import { logger as baseLogger } from '@/lib/logger'
 
 import { isK8sNotFound } from './k8s-error-utils'
 import { KubernetesUtils } from './kubernetes-utils'
+import { buildSandboxUrls } from './sandbox-endpoints'
 import { VERSIONS } from './versions'
 
 const logger = baseLogger.child({ module: 'lib/k8s/sandbox-manager' })
@@ -23,6 +24,8 @@ export interface SandboxInfo {
   ttydUrl: string
   /** File browser access URL */
   fileBrowserUrl: string
+  /** Editor access URL */
+  editorUrl: string
 }
 
 /**
@@ -125,27 +128,19 @@ export class SandboxManager {
     await this.createIngresses(sandboxName, k8sProjectName, namespace, serviceName, ingressDomain)
     logger.info(`Ingresses created for: ${sandboxName}`)
 
-    // Build ttydUrl with HTTP Basic Auth (authorization URL parameter)
-    // ttyd supports ?authorization=base64(username:password) for seamless auth without browser popup
-    // Username is fixed as 'user', password is the TTYD_ACCESS_TOKEN
-    const baseTtydUrl = `https://${sandboxName}-ttyd.${ingressDomain}`
-    const ttydAccessToken = envVars['TTYD_ACCESS_TOKEN']
-    let ttydUrl = baseTtydUrl
-    if (ttydAccessToken) {
-      const credentials = `user:${ttydAccessToken}`
-      const authBase64 = Buffer.from(credentials).toString('base64')
-      ttydUrl = `${baseTtydUrl}?authorization=${authBase64}`
-    }
-
-    // Build fileBrowserUrl (no token in URL, uses standard login)
-    const fileBrowserUrl = `https://${sandboxName}-filebrowser.${ingressDomain}`
+    const urls = buildSandboxUrls({
+      sandboxName,
+      ingressDomain,
+      ttydAccessToken: envVars['TTYD_ACCESS_TOKEN'],
+    })
 
     return {
       statefulSetName: sandboxName,
       serviceName: serviceName,
-      publicUrl: `https://${sandboxName}-app.${ingressDomain}`,
-      ttydUrl: ttydUrl,
-      fileBrowserUrl: fileBrowserUrl,
+      publicUrl: urls.publicUrl,
+      ttydUrl: urls.ttydUrl,
+      fileBrowserUrl: urls.fileBrowserUrl,
+      editorUrl: urls.editorUrl,
     }
   }
 
@@ -534,6 +529,184 @@ export class SandboxManager {
     }
   }
 
+  /**
+   * Expose a custom port on the sandbox
+   *
+   * Adds a port to the Service and creates an Ingress for it.
+   * Returns the public URL for the exposed port.
+   *
+   * @param namespace - Kubernetes namespace
+   * @param sandboxName - Sandbox name
+   * @param k8sProjectName - K8s project name (for labels)
+   * @param port - Port number to expose
+   * @param ingressDomain - Ingress domain
+   * @returns Public URL for the exposed port
+   */
+  async exposePort(
+    namespace: string,
+    sandboxName: string,
+    k8sProjectName: string,
+    port: number,
+    ingressDomain: string
+  ): Promise<string> {
+    logger.info(`Exposing port ${port} for sandbox ${sandboxName}`)
+
+    const serviceName = this.getServiceName(sandboxName)
+
+    // Step 1: Patch Service to add the port (read-then-replace to get full ports array)
+    try {
+      const serviceResponse = await this.k8sApi.readNamespacedService({ name: serviceName, namespace })
+      const service = (serviceResponse as { body?: k8s.V1Service }).body || (serviceResponse as k8s.V1Service)
+      const existingPorts = service.spec?.ports || []
+
+      // Check if port already exists in service
+      const portExists = existingPorts.some((p) => p.port === port)
+      if (!portExists) {
+        const updatedPorts = [
+          ...existingPorts,
+          { port, targetPort: port, name: `port-${port}`, protocol: 'TCP' },
+        ]
+
+        // Use JSON Patch format (consistent with other patches in this codebase)
+        await this.k8sApi.patchNamespacedService({
+          name: serviceName,
+          namespace,
+          body: [
+            {
+              op: 'replace',
+              path: '/spec/ports',
+              value: updatedPorts,
+            },
+          ],
+        })
+        logger.info(`Added port ${port} to Service ${serviceName}`)
+      }
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error)
+      logger.error(`Failed to patch Service for port ${port}: ${errorMessage}`)
+      throw error
+    }
+
+    // Step 2: Create Ingress for the port
+    const ingressName = `${sandboxName}-port${port}-ingress`
+    const host = `${sandboxName}-port${port}.${ingressDomain}`
+    const publicUrl = `https://${host}`
+
+    const ingress: k8s.V1Ingress = {
+      apiVersion: 'networking.k8s.io/v1',
+      kind: 'Ingress',
+      metadata: {
+        name: ingressName,
+        namespace,
+        labels: {
+          'cloud.sealos.io/app-deploy-manager': sandboxName,
+          'cloud.sealos.io/app-deploy-manager-domain': `${sandboxName}-port${port}`,
+          'project.fullstackagent.io/name': k8sProjectName,
+          'fullstackagent.io/custom-port': 'true',
+        },
+        annotations: {
+          'kubernetes.io/ingress.class': 'nginx',
+          'nginx.ingress.kubernetes.io/proxy-body-size': '32m',
+          'nginx.ingress.kubernetes.io/ssl-redirect': 'false',
+          'nginx.ingress.kubernetes.io/backend-protocol': 'HTTP',
+          'nginx.ingress.kubernetes.io/client-body-buffer-size': '64k',
+          'nginx.ingress.kubernetes.io/proxy-buffer-size': '64k',
+          'nginx.ingress.kubernetes.io/proxy-send-timeout': '300',
+          'nginx.ingress.kubernetes.io/proxy-read-timeout': '300',
+          'nginx.ingress.kubernetes.io/server-snippet':
+            'client_header_buffer_size 64k;\nlarge_client_header_buffers 4 128k;',
+        },
+      },
+      spec: {
+        rules: [
+          {
+            host,
+            http: {
+              paths: [
+                {
+                  pathType: 'Prefix',
+                  path: '/',
+                  backend: {
+                    service: {
+                      name: serviceName,
+                      port: { number: port },
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        ],
+        tls: [
+          {
+            hosts: [host],
+            secretName: 'wildcard-cert',
+          },
+        ],
+      },
+    }
+
+    await this.createIngressIfNotExists(ingressName, namespace, ingress)
+    logger.info(`Ingress created for port ${port}: ${publicUrl}`)
+
+    return publicUrl
+  }
+
+  /**
+   * Unexpose a custom port on the sandbox
+   *
+   * Removes the Ingress and the port from the Service.
+   *
+   * @param namespace - Kubernetes namespace
+   * @param sandboxName - Sandbox name
+   * @param port - Port number to unexpose
+   */
+  async unexposePort(
+    namespace: string,
+    sandboxName: string,
+    port: number
+  ): Promise<void> {
+    logger.info(`Unexposing port ${port} for sandbox ${sandboxName}`)
+
+    // Step 1: Delete the Ingress
+    const ingressName = `${sandboxName}-port${port}-ingress`
+    await this.deleteIngress(ingressName, namespace)
+
+    // Step 2: Remove the port from the Service
+    const serviceName = this.getServiceName(sandboxName)
+    try {
+      const serviceResponse = await this.k8sApi.readNamespacedService({ name: serviceName, namespace })
+      const service = (serviceResponse as { body?: k8s.V1Service }).body || (serviceResponse as k8s.V1Service)
+      const existingPorts = service.spec?.ports || []
+
+      const updatedPorts = existingPorts.filter((p) => p.port !== port)
+
+      if (updatedPorts.length !== existingPorts.length) {
+        // Use JSON Patch format (consistent with other patches in this codebase)
+        await this.k8sApi.patchNamespacedService({
+          name: serviceName,
+          namespace,
+          body: [
+            {
+              op: 'replace',
+              path: '/spec/ports',
+              value: updatedPorts,
+            },
+          ],
+        })
+        logger.info(`Removed port ${port} from Service ${serviceName}`)
+      }
+    } catch (error) {
+      if (isK8sNotFound(error)) {
+        logger.warn(`Service not found when removing port ${port}: ${serviceName}`)
+      } else {
+        throw error
+      }
+    }
+
+    logger.info(`Port ${port} unexposed for sandbox ${sandboxName}`)
+  }
+
   // ==================== Private Methods ====================
 
   /**
@@ -562,6 +735,13 @@ export class SandboxManager {
    */
   private getFileBrowserIngressName(sandboxName: string): string {
     return `${sandboxName}-filebrowser-ingress`
+  }
+
+  /**
+   * Get Editor ingress name
+   */
+  private getEditorIngressName(sandboxName: string): string {
+    return `${sandboxName}-editor-ingress`
   }
 
   /**
@@ -703,6 +883,7 @@ export class SandboxManager {
                 ports: [
                   { containerPort: 3000, name: 'port-3000' },
                   { containerPort: 7681, name: 'port-7681' },
+                  { containerPort: 3773, name: 'port-3773' },
                 ],
                 imagePullPolicy: 'Always',
                 volumeMounts: [
@@ -1014,6 +1195,7 @@ echo "=== Init Container: Completed successfully ==="
           { port: 3000, targetPort: 3000, name: 'port-3000', protocol: 'TCP' },
           { port: 7681, targetPort: 7681, name: 'port-7681', protocol: 'TCP' },
           { port: 8080, targetPort: 8080, name: 'port-8080', protocol: 'TCP' },
+          { port: 3773, targetPort: 3773, name: 'port-3773', protocol: 'TCP' },
         ],
         selector: {
           app: sandboxName,
@@ -1037,6 +1219,7 @@ echo "=== Init Container: Completed successfully ==="
     const appIngressName = this.getAppIngressName(sandboxName)
     const ttydIngressName = this.getTtydIngressName(sandboxName)
     const fileBrowserIngressName = this.getFileBrowserIngressName(sandboxName)
+    const editorIngressName = this.getEditorIngressName(sandboxName)
 
     const appIngress = this.createAppIngress(
       sandboxName,
@@ -1059,11 +1242,19 @@ echo "=== Init Container: Completed successfully ==="
       serviceName,
       ingressDomain
     )
+    const editorIngress = this.createEditorIngress(
+      sandboxName,
+      k8sProjectName,
+      namespace,
+      serviceName,
+      ingressDomain
+    )
 
     await Promise.all([
       this.createIngressIfNotExists(appIngressName, namespace, appIngress),
       this.createIngressIfNotExists(ttydIngressName, namespace, ttydIngress),
       this.createIngressIfNotExists(fileBrowserIngressName, namespace, fileBrowserIngress),
+      this.createIngressIfNotExists(editorIngressName, namespace, editorIngress),
     ])
   }
 
@@ -1300,6 +1491,77 @@ echo "=== Init Container: Completed successfully ==="
   }
 
   /**
+   * Create Editor ingress for code-server.
+   */
+  private createEditorIngress(
+    sandboxName: string,
+    k8sProjectName: string,
+    namespace: string,
+    serviceName: string,
+    ingressDomain: string
+  ): k8s.V1Ingress {
+    const ingressName = this.getEditorIngressName(sandboxName)
+    const host = `${sandboxName}-editor.${ingressDomain}`
+
+    return {
+      apiVersion: 'networking.k8s.io/v1',
+      kind: 'Ingress',
+      metadata: {
+        name: ingressName,
+        namespace,
+        labels: {
+          'cloud.sealos.io/app-deploy-manager': sandboxName,
+          'cloud.sealos.io/app-deploy-manager-domain': `${sandboxName}-editor`,
+          'project.fullstackagent.io/name': k8sProjectName,
+        },
+        annotations: {
+          'kubernetes.io/ingress.class': 'nginx',
+          'nginx.ingress.kubernetes.io/proxy-body-size': '32m',
+          'nginx.ingress.kubernetes.io/ssl-redirect': 'false',
+          'nginx.ingress.kubernetes.io/backend-protocol': 'HTTP',
+          'nginx.ingress.kubernetes.io/client-body-buffer-size': '64k',
+          'nginx.ingress.kubernetes.io/proxy-buffer-size': '64k',
+          'nginx.ingress.kubernetes.io/proxy-send-timeout': '300',
+          'nginx.ingress.kubernetes.io/proxy-read-timeout': '300',
+          // WebSocket support for code-server connections
+          'nginx.ingress.kubernetes.io/proxy-http-version': '1.1',
+          'nginx.ingress.kubernetes.io/configuration-snippet':
+            'proxy_set_header Upgrade $http_upgrade;\nproxy_set_header Connection "upgrade";',
+          'nginx.ingress.kubernetes.io/server-snippet':
+            'client_header_buffer_size 64k;\nlarge_client_header_buffers 4 128k;',
+        },
+      },
+      spec: {
+        rules: [
+          {
+            host,
+            http: {
+              paths: [
+                {
+                  pathType: 'Prefix',
+                  path: '/',
+                  backend: {
+                    service: {
+                      name: serviceName,
+                      port: { number: 3773 },
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        ],
+        tls: [
+          {
+            hosts: [host],
+            secretName: 'wildcard-cert',
+          },
+        ],
+      },
+    }
+  }
+
+  /**
    * Delete StatefulSet (exact deletion)
    */
   private async deleteStatefulSet(sandboxName: string, namespace: string): Promise<void> {
@@ -1343,18 +1605,41 @@ echo "=== Init Container: Completed successfully ==="
   }
 
   /**
-   * Delete Ingresses (exact deletion of App, Ttyd, and FileBrowser Ingress)
+   * Delete Ingresses (exact deletion of App, Ttyd, FileBrowser, and custom port Ingresses)
    */
   private async deleteIngresses(sandboxName: string, namespace: string): Promise<void> {
     const appIngressName = this.getAppIngressName(sandboxName)
     const ttydIngressName = this.getTtydIngressName(sandboxName)
     const fileBrowserIngressName = this.getFileBrowserIngressName(sandboxName)
+    const editorIngressName = this.getEditorIngressName(sandboxName)
 
-    await Promise.all([
+    // Delete built-in ingresses
+    const deletePromises: Promise<void>[] = [
       this.deleteIngress(appIngressName, namespace),
       this.deleteIngress(ttydIngressName, namespace),
       this.deleteIngress(fileBrowserIngressName, namespace),
-    ])
+      this.deleteIngress(editorIngressName, namespace),
+    ]
+
+    // Also delete any custom port ingresses via label selector
+    try {
+      const ingressList = await this.k8sNetworkingApi.listNamespacedIngress({
+        namespace,
+        labelSelector: `cloud.sealos.io/app-deploy-manager=${sandboxName},fullstackagent.io/custom-port=true`,
+      })
+      const items = (ingressList as { body?: { items: k8s.V1Ingress[] } }).body?.items
+        || (ingressList as { items: k8s.V1Ingress[] }).items
+        || []
+      for (const ingress of items) {
+        if (ingress.metadata?.name) {
+          deletePromises.push(this.deleteIngress(ingress.metadata.name, namespace))
+        }
+      }
+    } catch (error) {
+      logger.warn(`Failed to list custom port ingresses for ${sandboxName}: ${error}`)
+    }
+
+    await Promise.all(deletePromises)
   }
 
   /**

--- a/lib/k8s/versions.test.ts
+++ b/lib/k8s/versions.test.ts
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+test('VERSIONS.RUNTIME_IMAGE defaults to the GHCR runtime image', () => {
+  const source = readFileSync(new URL('./versions.ts', import.meta.url), 'utf8')
+  assert.match(
+    source,
+    /RUNTIME_IMAGE:\s*env\.RUNTIME_IMAGE\s*\|\|\s*'ghcr\.io\/fullagent\/fullstack-web-runtime:latest'/
+  )
+})
+
+test('VERSIONS.RUNTIME_IMAGE respects environment overrides', () => {
+  const source = readFileSync(new URL('./versions.ts', import.meta.url), 'utf8')
+  assert.match(source, /env\.RUNTIME_IMAGE/)
+})

--- a/lib/k8s/versions.ts
+++ b/lib/k8s/versions.ts
@@ -6,7 +6,7 @@ import { env } from '@/lib/env'
 
 export const VERSIONS = {
   // Runtime container image version - now using centralized version
-  RUNTIME_IMAGE: env.RUNTIME_IMAGE || 'docker.io/limbo2342/fullstack-web-runtime:sha-ca2470e',
+  RUNTIME_IMAGE: env.RUNTIME_IMAGE || 'ghcr.io/fullagent/fullstack-web-runtime:latest',
 
   // PostgreSQL version for KubeBlocks
   POSTGRESQL_VERSION: 'postgresql-14.8.0',

--- a/lib/repo/sandbox.ts
+++ b/lib/repo/sandbox.ts
@@ -182,13 +182,15 @@ export async function updateSandboxStatus(
  * @param publicUrl - Public application URL
  * @param ttydUrl - Terminal URL
  * @param fileBrowserUrl - File browser URL
+ * @param editorUrl - editor URL
  * @returns Updated sandbox
  */
 export async function updateSandboxUrls(
   sandboxId: string,
   publicUrl: string,
   ttydUrl: string,
-  fileBrowserUrl: string
+  fileBrowserUrl: string,
+  editorUrl: string
 ): Promise<Sandbox> {
   logger.info(`Updating sandbox ${sandboxId} URLs`)
 
@@ -198,6 +200,7 @@ export async function updateSandboxUrls(
       publicUrl,
       ttydUrl,
       fileBrowserUrl,
+      editorUrl,
       updatedAt: new Date(),
     },
   })

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,11 +15,9 @@ model User {
   updatedAt DateTime @updatedAt
 
   // Relations
-  identities          UserIdentity[] // One-to-many: User has multiple authentication identities
-  projects            Project[] // One-to-many: User owns multiple projects
-  configs             UserConfig[] // One-to-many: User global configurations
-  skills              UserSkill[] // One-to-many: User has multiple globally enabled skills
-  githubInstallations GitHubAppInstallation[] // One-to-many: User's GitHub App installations
+  identities UserIdentity[] // One-to-many: User has multiple authentication identities
+  projects   Project[] // One-to-many: User owns multiple projects
+  configs    UserConfig[] // One-to-many: User global configurations
 }
 
 model UserIdentity {
@@ -66,37 +64,6 @@ model UserConfig {
   @@index([userId, category])
 }
 
-// GitHubAppInstallation: Tracks GitHub App installations
-// Required for obtaining installation access tokens
-model GitHubAppInstallation {
-  id             String @id @default(cuid())
-  installationId Int    @unique // GitHub's numeric installation ID
-  userId         String
-
-  accountId        Int // GitHub account numeric ID
-  accountLogin     String // GitHub username or organization name
-  accountType      String // "User" or "Organization"
-  accountAvatarUrl String?
-
-  repositorySelection String // "all" or "selected"
-
-  permissions Json @default("{}") // App permissions
-  events      Json @default("[]") // Subscribed events
-
-  status      GitHubInstallationStatus @default(ACTIVE)
-  suspendedAt DateTime?
-
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-
-  // Relations
-  user     User      @relation(fields: [userId], references: [id], onDelete: Cascade)
-  projects Project[] // Reverse relation: which projects use this installation
-
-  @@index([userId])
-  @@index([accountId])
-}
-
 // Project: Abstract resource collection
 // Status is derived from child resources (databases, sandboxes, environments)
 model Project {
@@ -104,15 +71,8 @@ model Project {
   name        String // Display name
   description String?
   userId      String
-
-  /// @deprecated Use githubAppInstallation + githubRepoId + githubRepoFullName instead
-  githubRepo String? // Optional GitHub repository (legacy)
-
-  // GitHub App integration (Phase 1: Expand)
-  githubAppInstallationId String? // FK → GitHubAppInstallation
-  githubRepoId            Int? // GitHub repo numeric ID (stable across renames)
-  githubRepoFullName      String? // "owner/repo-name", for display
-  githubRepoDefaultBranch String? // Repository default branch for import workflow
+  githubRepo   String? // Optional GitHub repository (full_name e.g. "owner/repo")
+  githubBranch String? // Optional branch to clone
 
   // Aggregated status based on child resources
   status ProjectStatus @default(CREATING)
@@ -121,14 +81,11 @@ model Project {
   updatedAt DateTime @updatedAt
 
   // Relations: Project is a collection of resources
-  user                  User                   @relation(fields: [userId], references: [id], onDelete: Cascade) // Many-to-one: Project belongs to a User
-  environments          Environment[] // One-to-many: Configuration variables
-  databases             Database[] // One-to-many: Multiple database clusters
-  sandboxes             Sandbox[] // One-to-many: Multiple runtime containers
-  tasks                 ProjectTask[] // One-to-many: Project-level asynchronous tasks
-  githubAppInstallation GitHubAppInstallation? @relation(fields: [githubAppInstallationId], references: [id], onDelete: SetNull)
-
-  @@index([githubAppInstallationId])
+  user         User          @relation(fields: [userId], references: [id], onDelete: Cascade) // Many-to-one: Project belongs to a User
+  environments Environment[] // One-to-many: Configuration variables
+  databases    Database[] // One-to-many: Multiple database clusters
+  sandboxes    Sandbox[] // One-to-many: Multiple runtime containers
+  brainSessions BrainSession[] // One-to-many: Brain UI sessions
 }
 
 // Environment: Configuration key-value pairs for the project
@@ -209,6 +166,8 @@ model Sandbox {
   publicUrl      String? // App ingress (port 3000)
   ttydUrl        String? // Terminal ingress (port 7681)
   fileBrowserUrl String? // File browser ingress (port 8080)
+  editorUrl      String? // Editor ingress (port 3773)
+  brainUrl       String? // t3 code AI assistant ingress (port 3773)
 
   // Resource status (managed independently)
   status ResourceStatus @default(CREATING)
@@ -216,6 +175,9 @@ model Sandbox {
   // Optimistic locking to prevent concurrent updates
   // Reconcile job uses this to lock the sandbox and prevent concurrent updates
   lockedUntil DateTime? // Locked until this timestamp, null means unlocked
+
+  // Custom exposed ports (array of {port: number, url: string})
+  exposedPorts Json @default("[]")
 
   // Runtime configuration
   runtimeImage  String? // Docker image tag
@@ -228,8 +190,8 @@ model Sandbox {
   updatedAt DateTime @updatedAt
 
   // Relation: Many-to-one to Project (foreign key: projectId)
-  project Project       @relation(fields: [projectId], references: [id], onDelete: Cascade)
-  tasks   ProjectTask[]
+  project Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  brainSessions BrainSession[] // One-to-many: Brain UI sessions bound to this sandbox
 
   @@unique([projectId, name]) // Unique sandbox name per project
   @@unique([k8sNamespace, sandboxName]) // Unique sandbox name per namespace
@@ -237,51 +199,28 @@ model Sandbox {
   @@index([sandboxName])
 }
 
-model UserSkill {
-  id             String   @id @default(cuid())
-  userId         String
-  skillId        String
-  installCommand String
-  createdAt      DateTime @default(now())
-  updatedAt      DateTime @updatedAt
-
-  user  User          @relation(fields: [userId], references: [id], onDelete: Cascade)
-  tasks ProjectTask[]
-
-  @@unique([userId, skillId])
-  @@index([userId])
-  @@index([skillId])
-}
-
-model ProjectTask {
-  id            String                   @id @default(cuid())
+model BrainSession {
+  id           String @id @default(cuid())
   projectId     String
   sandboxId     String?
-  userSkillId   String?
-  skillId       String?
-  type          ProjectTaskType
-  status        ProjectTaskStatus        @default(PENDING)
-  triggerSource ProjectTaskTriggerSource
-  payload       Json?
-  result        Json?
-  error         String?
-  attemptCount  Int                      @default(0)
-  maxAttempts   Int                      @default(3)
-  lockedUntil   DateTime?
-  startedAt     DateTime?
-  finishedAt    DateTime?
-  createdAt     DateTime                 @default(now())
-  updatedAt     DateTime                 @updatedAt
+  title         String
+  workspaceRoot String
+  t3ProjectId   String?
+  t3ThreadId    String?
+  status        BrainSessionStatus @default(OPEN)
+  sortOrder     Int @default(0)
+  lastOpenedAt  DateTime? @default(now())
+  closedAt      DateTime?
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
 
-  project   Project   @relation(fields: [projectId], references: [id], onDelete: Cascade)
-  sandbox   Sandbox?  @relation(fields: [sandboxId], references: [id], onDelete: SetNull)
-  userSkill UserSkill? @relation(fields: [userSkillId], references: [id], onDelete: SetNull)
+  project Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  sandbox Sandbox? @relation(fields: [sandboxId], references: [id], onDelete: SetNull)
 
-  @@index([projectId, status])
-  @@index([status, lockedUntil])
-  @@index([type, status])
-  @@index([projectId, skillId, type, status])
-  @@index([userSkillId])
+  @@index([projectId, sortOrder])
+  @@index([projectId, workspaceRoot])
+  @@index([sandboxId])
+  @@index([status, closedAt])
 }
 
 // Project aggregated status based on child resources
@@ -314,28 +253,6 @@ enum ProjectStatus {
   PARTIAL // Inconsistent mixed states - manual intervention needed
 }
 
-enum ProjectTaskType {
-  CLONE_REPOSITORY
-  INSTALL_SKILL
-  UNINSTALL_SKILL
-  DEPLOY_PROJECT
-}
-
-enum ProjectTaskStatus {
-  PENDING
-  WAITING_FOR_PREREQUISITES
-  RUNNING
-  SUCCEEDED
-  FAILED
-  CANCELLED
-}
-
-enum ProjectTaskTriggerSource {
-  USER_ACTION
-  SYSTEM_EVENT
-  POLICY_ROLLOUT
-}
-
 // Individual resource status (Database and Sandbox)
 // Follows K8s resource lifecycle with transition states
 enum ResourceStatus {
@@ -350,15 +267,15 @@ enum ResourceStatus {
   UPDATING // Resource is being updated
 }
 
+enum BrainSessionStatus {
+  OPEN
+  CLOSED
+  ERROR
+}
+
 enum AuthProvider {
   PASSWORD // Email/password authentication
   GITHUB // GitHub OAuth
   GOOGLE // Google OAuth (future)
   SEALOS // Sealos OAuth
-}
-
-enum GitHubInstallationStatus {
-  ACTIVE // Installation is active and operational
-  SUSPENDED // Installation is suspended by GitHub
-  DELETED // Installation was deleted
 }

--- a/runtime/.bashrc
+++ b/runtime/.bashrc
@@ -51,12 +51,3 @@ PROMPT_COMMAND=_ps1_update
 #     cd "$HOME/next"
 # fi
 
-# Auto-start Claude Code CLI on first terminal connection only
-# Use a file flag that persists across ttyd reconnections
-CLAUDE_FLAG_FILE="/tmp/.claude_started"
-
-if [ ! -f "$CLAUDE_FLAG_FILE" ]; then
-    touch "$CLAUDE_FLAG_FILE"
-    echo "🤖 Starting Claude Code CLI..."
-    claude
-fi

--- a/runtime/.tmux.conf
+++ b/runtime/.tmux.conf
@@ -1,0 +1,15 @@
+# FullstackAgent tmux configuration
+# Persistent terminal sessions for web terminal
+
+# Disable status bar for clean terminal appearance
+set -g status off
+
+# 256 color and true color support
+set -g default-terminal "xterm-256color"
+set -ga terminal-overrides ",xterm-256color:Tc"
+
+# Large scrollback buffer
+set -g history-limit 50000
+
+# Enable mouse support (scroll, click, resize panes)
+set -g mouse on

--- a/runtime/Dockerfile
+++ b/runtime/Dockerfile
@@ -20,18 +20,14 @@ LABEL maintainer="FullstackAgent" \
 ENV DEBIAN_FRONTEND=noninteractive \
     NODE_VERSION=22.x \
     NEXT_VERSION=15.5.9 \
-    CLAUDE_CODE_VERSION=latest \
+    CODE_SERVER_VERSION=4.104.3 \
     PATH="/root/.local/bin:/home/fulling/.local/bin:$PATH" \
     TERM=xterm-256color \
     COLORTERM=truecolor \
     LANG=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8 \
-    ANTHROPIC_BASE_URL="" \
-    ANTHROPIC_AUTH_TOKEN="" \
-    ANTHROPIC_MODEL="" \
-    ANTHROPIC_SMALL_FAST_MODEL="" \
-    GEMINI_API_KEY="" \
-    OPENAI_API_KEY="" \
+    CODEX_API_KEY="" \
+    CODEX_BASE_URL="" \
     DOCKER_HUB_NAME="" \
     DOCKER_HUB_PASSWD=""
 
@@ -81,12 +77,10 @@ RUN set -eux; \
 
 # -----------------------------------------------------------------------------
 # Install global npm packages in a single layer
-# Includes CLI tools for Next.js, package managers, deployment, and AI assistance
+# Includes CLI tools for Next.js, package managers, deployment, and Codex AI assistant
 # -----------------------------------------------------------------------------
 RUN npm install -g \
-        @anthropic-ai/claude-code \
-        @google/gemini-cli \
-        @openai/codex \
+        @openai/codex@latest \
         create-next-app@${NEXT_VERSION} \
         pnpm \
         prisma \
@@ -163,7 +157,9 @@ RUN set -eux; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
         bat \
+        bubblewrap \
         dnsutils \
+        dtach \
         fd-find \
         gh \
         htop \
@@ -206,11 +202,20 @@ WORKDIR /home/fulling/next
 # Copy configuration files (placed before user switch for better caching)
 # entrypoint.sh: Container startup script
 # ttyd-startup.sh: Startup script for ttyd (session tracking, welcome message)
-# .bashrc: Shell configuration with custom prompt and Claude CLI auto-start
+# .bashrc: Shell configuration with custom prompt
 # -----------------------------------------------------------------------------
-COPY --chmod=755 entrypoint.sh /usr/local/bin/entrypoint.sh
-COPY --chmod=755 ttyd-startup.sh /usr/local/bin/ttyd-startup.sh
-COPY --chmod=644 .bashrc /etc/skel/.bashrc
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY ttyd-auth.sh /usr/local/bin/ttyd-auth.sh
+COPY .bashrc /etc/skel/.bashrc
+COPY .tmux.conf /etc/skel/.tmux.conf
+RUN chmod 755 /usr/local/bin/entrypoint.sh /usr/local/bin/ttyd-auth.sh && chmod 644 /etc/skel/.bashrc /etc/skel/.tmux.conf
+
+# -----------------------------------------------------------------------------
+# Install code-server for the embedded editor
+# -----------------------------------------------------------------------------
+RUN set -eux; \
+    curl -fsSL https://code-server.dev/install.sh | sh -s -- --version "${CODE_SERVER_VERSION}"; \
+    code-server --version
 
 # =============================================================================
 # Stage 2: Next.js project template preparation
@@ -301,7 +306,7 @@ RUN set -eux; \
 # 5432: PostgreSQL client connections
 # 7681: ttyd web terminal
 # -----------------------------------------------------------------------------
-EXPOSE 3000 3001 5000 5173 8080 8000 5432 7681
+EXPOSE 3000 3001 3773 5000 5173 8080 8000 5432 7681
 
 # -----------------------------------------------------------------------------
 # Health check configuration
@@ -316,6 +321,6 @@ HEALTHCHECK --interval=2m --timeout=30s --start-period=1m --retries=3 \
 # -----------------------------------------------------------------------------
 # Container entrypoint
 # Starts ttyd web terminal which provides browser-based shell access
-# The .bashrc will auto-start Claude Code CLI on first connection
+# Codex configuration is written from environment variables at startup
 # -----------------------------------------------------------------------------
 CMD ["/usr/local/bin/entrypoint.sh"]

--- a/runtime/build.sh
+++ b/runtime/build.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# =============================================================================
+# Build the runtime Docker image
+# =============================================================================
+#
+# This script builds the runtime Docker image locally.
+#
+# Usage:
+#   cd runtime && ./build.sh
+#
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Read version
+VERSION=$(cat "$SCRIPT_DIR/VERSION" 2>/dev/null || echo "latest")
+IMAGE_REPO="${IMAGE_REPO:-ghcr.io/fullagent/fullstack-web-runtime}"
+IMAGE_NAME="${IMAGE_REPO}:${VERSION}"
+
+echo "=== Building runtime image: ${IMAGE_NAME} ==="
+
+# Remove legacy T3 build artifacts if they are present from older worktrees.
+rm -rf "$SCRIPT_DIR/t3code-dist"
+
+# Build Docker image
+echo "=== Building Docker image ==="
+docker build -t "$IMAGE_NAME" "$SCRIPT_DIR"
+
+echo ""
+echo "✓ Image built: ${IMAGE_NAME}"
+echo "  Run: docker push ${IMAGE_NAME}"

--- a/runtime/build.test.sh
+++ b/runtime/build.test.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+runtime_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+fake_bin="$tmpdir/bin"
+docker_args="$tmpdir/docker-args.txt"
+docker_tag="$tmpdir/docker-tag.txt"
+docker_context="$tmpdir/docker-context.txt"
+docker_t3_dir_state="$tmpdir/docker-t3-dir-state.txt"
+mkdir -p "$fake_bin"
+
+cat > "$fake_bin/docker" <<EOF
+#!/usr/bin/env bash
+context="\${!#}"
+printf '%s\n' "\$3" > "$docker_tag"
+printf '%s\n' "\$context" > "$docker_context"
+if [ -d "\$context/t3code-dist" ]; then
+  echo present > "$docker_t3_dir_state"
+else
+  echo missing > "$docker_t3_dir_state"
+fi
+printf '%s\n' "\$@" > "$docker_args"
+exit 0
+EOF
+chmod +x "$fake_bin/docker"
+
+PATH="$fake_bin:/usr/bin:/bin" \
+bash "$runtime_dir/build.sh"
+
+grep -qx 'build' "$docker_args"
+grep -qx 'ghcr.io/fullagent/fullstack-web-runtime:latest' "$docker_tag"
+grep -qx "$runtime_dir" "$docker_context"
+grep -qx 'missing' "$docker_t3_dir_state"

--- a/runtime/entrypoint.sh
+++ b/runtime/entrypoint.sh
@@ -1,39 +1,110 @@
 #!/bin/bash
 # =============================================================================
-# ttyd Entrypoint Script
+# Sandbox Entrypoint Script
 # =============================================================================
 #
-# Starts ttyd web terminal with HTTP Basic Auth enabled.
+# Sets up Codex configuration, starts code-server, and starts ttyd web terminal.
 #
 # Authentication Flow:
-# 1. ttyd validates credentials at HTTP/WebSocket layer via -c parameter
-# 2. URL format: ?authorization=base64(user:password)&arg=SESSION_ID
-# 3. ttyd-startup.sh handles session tracking (not auth) for file upload cwd detection
+#   ttyd-auth.sh receives the access token via ?arg=TOKEN and validates it
+#   against the TTYD_ACCESS_TOKEN environment variable.
 #
 # Required Environment Variables:
-#   TTYD_ACCESS_TOKEN - Password for HTTP Basic Auth (username is 'user')
+#   TTYD_ACCESS_TOKEN - Access token for terminal authentication
 #
-# Optional URL Parameters (via -a flag):
-#   arg=SESSION_ID - Terminal session ID for file upload directory tracking
+# Optional Environment Variables:
+#   CODEX_API_KEY  - API key for Codex (written to ~/.codex/auth.json)
+#   CODEX_BASE_URL - LLM API base URL for Codex (written to ~/.codex/config.toml)
 #
 # =============================================================================
 
 set -euo pipefail
 
+FULLING_USER="${FULLING_USER:-fulling}"
+FULLING_GROUP="${FULLING_GROUP:-fulling}"
+FULLING_HOME="${FULLING_HOME:-/home/fulling}"
+SKEL_DIR="${SKEL_DIR:-/etc/skel}"
+TTYD_AUTH_SCRIPT="${TTYD_AUTH_SCRIPT:-/usr/local/bin/ttyd-auth.sh}"
+FULLING_WORKSPACE="${FULLING_WORKSPACE:-$FULLING_HOME/next}"
+EDITOR_PASSWORD="${EDITOR_PASSWORD:-${TTYD_ACCESS_TOKEN:-}}"
+
+maybe_chown() {
+    if [ "$(id -u)" -eq 0 ]; then
+        chown "$@"
+    fi
+}
+
+mkdir -p "$FULLING_HOME"
+mkdir -p "$FULLING_WORKSPACE"
+export HOME="$FULLING_HOME"
+export USER="$FULLING_USER"
+export LOGNAME="$FULLING_USER"
+export CODEX_HOME="${CODEX_HOME:-$FULLING_HOME/.codex}"
+
 # -----------------------------------------------------------------------------
 # Validate required environment variables
 # -----------------------------------------------------------------------------
-if [ -z "$TTYD_ACCESS_TOKEN" ]; then
+if [ -z "${TTYD_ACCESS_TOKEN:-}" ]; then
     echo "ERROR: TTYD_ACCESS_TOKEN environment variable is not set"
     echo "This is required for terminal authentication"
     exit 1
 fi
 
 # -----------------------------------------------------------------------------
-# Build HTTP Basic Auth credential
-# Format: username:password (username is fixed as 'user')
+# Copy shell config files from skeleton to PVC-mounted home directory
+# On first run the PVC is empty, so .bashrc needs to be copied
 # -----------------------------------------------------------------------------
-TTYD_CREDENTIAL="user:${TTYD_ACCESS_TOKEN}"
+for skelfile in .bashrc .tmux.conf; do
+    if [ ! -f "$FULLING_HOME/$skelfile" ] && [ -f "$SKEL_DIR/$skelfile" ]; then
+        cp "$SKEL_DIR/$skelfile" "$FULLING_HOME/$skelfile"
+        maybe_chown "$FULLING_USER:$FULLING_GROUP" "$FULLING_HOME/$skelfile"
+    fi
+done
+
+# -----------------------------------------------------------------------------
+# Setup Codex configuration
+# Writes ~/.codex/config.toml and ~/.codex/auth.json from environment variables.
+# These are regenerated on every container start so settings changes take effect
+# after pod restart.
+# -----------------------------------------------------------------------------
+CODEX_CONFIG_DIR="$CODEX_HOME"
+CODEX_CONFIG_FILE="${CODEX_CONFIG_DIR}/config.toml"
+CODEX_AUTH_FILE="${CODEX_CONFIG_DIR}/auth.json"
+
+# Write config.toml if CODEX_BASE_URL is set
+if [ -n "${CODEX_BASE_URL:-}" ]; then
+    mkdir -p "$CODEX_CONFIG_DIR"
+    cat > "$CODEX_CONFIG_FILE" << CODEX_CONFIG_EOF
+service_tier = "fast"
+model_provider = "litellm"
+
+[model_providers.litellm]
+name = "OpenAI"
+base_url = "${CODEX_BASE_URL}"
+wire_api = "responses"
+requires_openai_auth = true
+CODEX_CONFIG_EOF
+    maybe_chown "$FULLING_USER:$FULLING_GROUP" "$CODEX_CONFIG_FILE"
+    echo "✓ Codex config initialized (base_url: ${CODEX_BASE_URL})"
+fi
+
+# Write auth.json if CODEX_API_KEY is set
+if [ -n "${CODEX_API_KEY:-}" ]; then
+    mkdir -p "$CODEX_CONFIG_DIR"
+    cat > "$CODEX_AUTH_FILE" << CODEX_AUTH_EOF
+{
+  "auth_mode": "apikey",
+  "OPENAI_API_KEY": "${CODEX_API_KEY}"
+}
+CODEX_AUTH_EOF
+    maybe_chown "$FULLING_USER:$FULLING_GROUP" "$CODEX_AUTH_FILE"
+    echo "✓ Codex auth configured"
+fi
+
+# Ensure proper ownership of codex config directory
+if [ -d "$CODEX_CONFIG_DIR" ]; then
+    maybe_chown -R "$FULLING_USER:$FULLING_GROUP" "$CODEX_CONFIG_DIR" 2>/dev/null || true
+fi
 
 # -----------------------------------------------------------------------------
 # Terminal theme configuration
@@ -62,34 +133,60 @@ THEME='theme={
 }'
 
 # -----------------------------------------------------------------------------
-# Verify startup script exists
+# Configure and start code-server as a background daemon.
+# The editor listens on port 3773 and serves the project workspace.
 # -----------------------------------------------------------------------------
-if [ ! -f /usr/local/bin/ttyd-startup.sh ]; then
-    echo "ERROR: ttyd-startup.sh not found at /usr/local/bin/ttyd-startup.sh"
+CODE_SERVER_CONFIG_DIR="${FULLING_HOME}/.config/code-server"
+CODE_SERVER_CONFIG_FILE="${CODE_SERVER_CONFIG_DIR}/config.yaml"
+
+mkdir -p "$CODE_SERVER_CONFIG_DIR"
+cat > "$CODE_SERVER_CONFIG_FILE" << CODE_SERVER_CONFIG_EOF
+bind-addr: 0.0.0.0:3773
+auth: password
+password: ${EDITOR_PASSWORD}
+cert: false
+CODE_SERVER_CONFIG_EOF
+maybe_chown -R "$FULLING_USER:$FULLING_GROUP" "$CODE_SERVER_CONFIG_DIR"
+
+if command -v code-server >/dev/null 2>&1; then
+    echo "Starting code-server (port 3773)..."
+    PASSWORD="$EDITOR_PASSWORD" \
+    HOME="$HOME" \
+    USER="$USER" \
+    LOGNAME="$LOGNAME" \
+    CODEX_HOME="$CODEX_HOME" \
+    nohup code-server "$FULLING_WORKSPACE" > /tmp/code-server.log 2>&1 &
+    echo "✓ code-server started (PID: $!)"
+else
+    echo "ERROR: code-server is not installed"
     exit 1
 fi
 
 # -----------------------------------------------------------------------------
-# Start ttyd with authentication
+# Verify auth script exists
+# -----------------------------------------------------------------------------
+if [ ! -f "$TTYD_AUTH_SCRIPT" ]; then
+    echo "ERROR: ttyd-auth.sh not found at $TTYD_AUTH_SCRIPT"
+    exit 1
+fi
+
+# -----------------------------------------------------------------------------
+# Start ttyd with token-based authentication
 # -----------------------------------------------------------------------------
 # Parameters:
-#   -T xterm-256color  : Terminal type (widely supported)
+#   -T xterm-256color  : Terminal type
 #   -W                 : Enable WebSocket compression
-#   -a                 : Allow URL arguments (?arg=SESSION_ID) to be passed to command
-#   -c credential      : HTTP Basic Auth (user:password)
+#   -a                 : Allow URL arguments (?arg=TOKEN&arg=SESSION_ID)
 #   -t theme           : Terminal color theme
 #
-# The command (ttyd-startup.sh) receives URL arguments:
-#   $1 = SESSION_ID (from ?arg=...)
-#
-# Authentication happens at HTTP/WebSocket level by ttyd.
-# ttyd-startup.sh only handles session tracking for file upload cwd detection.
+# ttyd-auth.sh receives:
+#   $1 = ACCESS_TOKEN (from first ?arg=)
+#   $2 = SESSION_ID (from second ?arg=)
 # -----------------------------------------------------------------------------
-echo "Starting ttyd with HTTP Basic Auth..."
+echo "Starting ttyd..."
 exec ttyd \
     -T xterm-256color \
     -W \
     -a \
-    -c "$TTYD_CREDENTIAL" \
     -t "$THEME" \
-    /usr/local/bin/ttyd-startup.sh
+    "$TTYD_AUTH_SCRIPT"

--- a/runtime/entrypoint.test.sh
+++ b/runtime/entrypoint.test.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+runtime_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+fake_home="$tmpdir/home/fulling"
+fake_workspace="$tmpdir/workspace"
+fake_skel="$tmpdir/skel"
+fake_bin="$tmpdir/bin"
+fake_auth="$tmpdir/ttyd-auth.sh"
+env_dump="$tmpdir/ttyd-env.txt"
+ttyd_args_dump="$tmpdir/ttyd-args.txt"
+code_server_env_dump="$tmpdir/code-server-env.txt"
+code_server_args_dump="$tmpdir/code-server-args.txt"
+
+mkdir -p "$fake_home" "$fake_workspace" "$fake_skel" "$fake_bin"
+
+printf 'export PS1="test"\n' > "$fake_skel/.bashrc"
+printf 'set -g mouse on\n' > "$fake_skel/.tmux.conf"
+
+cat > "$fake_auth" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$fake_auth"
+
+cat > "$fake_bin/ttyd" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$@" > "$ttyd_args_dump"
+printf 'HOME=%s\nUSER=%s\nLOGNAME=%s\nCODEX_HOME=%s\nAUTH_SCRIPT=%s\n' \
+  "\$HOME" "\${USER:-}" "\${LOGNAME:-}" "\${CODEX_HOME:-}" "\${!#}" > "$env_dump"
+exit 0
+EOF
+chmod +x "$fake_bin/ttyd"
+
+cat > "$fake_bin/code-server" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$@" > "$code_server_args_dump"
+printf 'HOME=%s\nUSER=%s\nLOGNAME=%s\nCODEX_HOME=%s\nPASSWORD=%s\n' \
+  "\$HOME" "\${USER:-}" "\${LOGNAME:-}" "\${CODEX_HOME:-}" "\${PASSWORD:-}" > "$code_server_env_dump"
+exit 0
+EOF
+chmod +x "$fake_bin/code-server"
+
+FULLING_HOME="$fake_home" \
+FULLING_WORKSPACE="$fake_workspace" \
+SKEL_DIR="$fake_skel" \
+TTYD_AUTH_SCRIPT="$fake_auth" \
+PATH="$fake_bin:$PATH" \
+HOME=/root \
+USER=root \
+LOGNAME=root \
+TTYD_ACCESS_TOKEN=test-token \
+EDITOR_PASSWORD=editor-secret \
+CODEX_BASE_URL=https://proxy.example/v1 \
+CODEX_API_KEY=test-key \
+bash "$runtime_dir/entrypoint.sh"
+
+test -f "$fake_home/.codex/config.toml"
+test -f "$fake_home/.codex/auth.json"
+test -f "$fake_home/.config/code-server/config.yaml"
+
+grep -q 'model_provider = "litellm"' "$fake_home/.codex/config.toml"
+grep -q 'OPENAI_API_KEY' "$fake_home/.codex/auth.json"
+grep -q '^bind-addr: 0.0.0.0:3773$' "$fake_home/.config/code-server/config.yaml"
+grep -q '^auth: password$' "$fake_home/.config/code-server/config.yaml"
+grep -q '^password: editor-secret$' "$fake_home/.config/code-server/config.yaml"
+grep -q '^cert: false$' "$fake_home/.config/code-server/config.yaml"
+
+grep -q "^HOME=$fake_home$" "$env_dump"
+grep -q "^CODEX_HOME=$fake_home/.codex$" "$env_dump"
+grep -q "^AUTH_SCRIPT=$fake_auth$" "$env_dump"
+grep -qx -- '-T' "$ttyd_args_dump"
+grep -qx -- 'xterm-256color' "$ttyd_args_dump"
+grep -qx -- '-W' "$ttyd_args_dump"
+grep -qx -- '-a' "$ttyd_args_dump"
+! grep -qx -- '-c' "$ttyd_args_dump"
+
+grep -q "^HOME=$fake_home$" "$code_server_env_dump"
+grep -q "^CODEX_HOME=$fake_home/.codex$" "$code_server_env_dump"
+grep -q '^PASSWORD=editor-secret$' "$code_server_env_dump"
+grep -qx -- "$fake_workspace" "$code_server_args_dump"

--- a/runtime/ttyd-auth.sh
+++ b/runtime/ttyd-auth.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# ttyd authentication wrapper script
+# Validates TTYD_ACCESS_TOKEN before granting shell access
+# Uses tmux for per-session persistence (survives browser refresh/tab close)
+#
+# Arguments (passed via URL ?arg=...&arg=...):
+#   $1 - TTYD_ACCESS_TOKEN (required)
+#   $2 - TERMINAL_SESSION_ID (optional, for session persistence + file upload CWD)
+
+# Get the expected token from environment variable
+EXPECTED_TOKEN="${TTYD_ACCESS_TOKEN:-}"
+
+# Check if token is configured
+if [ -z "$EXPECTED_TOKEN" ]; then
+    echo "ERROR: TTYD_ACCESS_TOKEN is not configured"
+    echo "Please contact your system administrator"
+    sleep infinity
+fi
+
+# Check if token was provided as argument
+if [ "$#" -lt 1 ]; then
+    echo "ERROR: Authentication failed - no token provided"
+    sleep infinity
+fi
+
+PROVIDED_TOKEN="$1"
+
+# Validate token
+if [ "$PROVIDED_TOKEN" != "$EXPECTED_TOKEN" ]; then
+    echo "ERROR: Authentication failed - invalid token"
+    sleep infinity
+fi
+
+# Authentication successful
+echo "✓ Authentication successful"
+
+# Handle terminal session ID
+SESSION_FILE=""
+TERMINAL_SESSION_ID=""
+TMUX_SESSION_NAME=""
+if [ "$#" -ge 2 ] && [ -n "$2" ]; then
+    # Validate format: only allow alphanumeric, hyphens, and underscores
+    if [[ ! "$2" =~ ^[a-zA-Z0-9_-]+$ ]]; then
+        echo "ERROR: Invalid session ID format"
+        sleep infinity
+    fi
+    TERMINAL_SESSION_ID="$2"
+    export TERMINAL_SESSION_ID
+    SESSION_FILE="/tmp/.terminal-session-${TERMINAL_SESSION_ID}"
+    TMUX_SESSION_NAME="terminal-${TERMINAL_SESSION_ID}"
+fi
+
+write_tmux_pane_pid() {
+    if [ -z "$SESSION_FILE" ] || [ -z "$TMUX_SESSION_NAME" ]; then
+        return
+    fi
+
+    PANE_PID="$(tmux display-message -p -t "$TMUX_SESSION_NAME":0 '#{pane_pid}' 2>/dev/null | tr -d '\r\n')"
+    if [ -n "$PANE_PID" ]; then
+        echo "$PANE_PID" > "$SESSION_FILE"
+    fi
+}
+
+if [ -n "$TERMINAL_SESSION_ID" ]; then
+    if tmux has-session -t "$TMUX_SESSION_NAME" 2>/dev/null; then
+        echo "↻ Reconnecting to session..."
+        write_tmux_pane_pid
+        exec tmux attach-session -t "$TMUX_SESSION_NAME"
+    else
+        echo ""
+        echo "Welcome to your FullstackAgent Sandbox!"
+        echo "========================================"
+        echo ""
+        echo "  codex         - Start AI coding assistant"
+        echo "  pnpm install  - Install dependencies"
+        echo "  pnpm dev      - Start dev server"
+        echo ""
+
+        tmux new-session -d -s "$TMUX_SESSION_NAME" /bin/bash
+        sleep 0.2
+        write_tmux_pane_pid
+        exec tmux attach-session -t "$TMUX_SESSION_NAME"
+    fi
+else
+    # No session ID — plain bash (fallback)
+    if [ -n "$SESSION_FILE" ]; then
+        echo "$$" > "$SESSION_FILE"
+    fi
+
+    echo ""
+    echo "Welcome to your FullstackAgent Sandbox!"
+    echo "========================================"
+    echo ""
+    echo "  codex         - Start AI coding assistant"
+    echo "  pnpm install  - Install dependencies"
+    echo "  pnpm dev      - Start dev server"
+    echo ""
+
+    exec /bin/bash
+fi


### PR DESCRIPTION
## Summary
- replace the sandbox editor runtime with code-server on port 3773
- add dedicated editor URL plumbing and editor password handling for sandboxes
- route the Editor tab to editorUrl and surface editor credentials in the network dialog
- switch default runtime image references to GHCR and add focused runtime/url tests

## Verification
- bash runtime/entrypoint.test.sh
- bash runtime/build.test.sh
- node --test lib/k8s/sandbox-endpoints.test.ts
- node --test components/terminal/toolbar/network-endpoints.test.ts