### PR TITLE
feat: add MiniMax as first-class LLM provider

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -34,6 +34,10 @@ RUNTIME_IMAGE=""
 AIPROXY_ENDPOINT=""
 ANTHROPIC_BASE_URL=""
 
+# MiniMax (OpenAI-compatible API)
+MINIMAX_BASE_URL="https://api.minimax.io/v1"
+MINIMAX_MODEL=""
+
 # Log
 LOG_LEVEL="info"
 

--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ See [CHANGELOG.md](CHANGELOG.md) for release history.
 ## Acknowledgments
 
 - [Anthropic](https://www.anthropic.com/) for Claude Code
+- [MiniMax](https://www.minimax.io/) for MiniMax AI models (M2.7, M2.5-highspeed)
 - [Sealos](https://sealos.io/) for Kubernetes platform
 - [ttyd](https://github.com/tsl0922/ttyd) for web terminal
 - [FileBrowser](https://github.com/filebrowser/filebrowser) for file management
@@ -225,5 +226,5 @@ See [CHANGELOG.md](CHANGELOG.md) for release history.
 
 <div align="center">
 <strong>100% AI-generated code.</strong> Prompted by [@fanux](https://github.com/fanux).
-<br>Powered by Claude Code, with models from Anthropic (Sonnet, Opus), Google (Gemini), Zhipu AI (GLM), and Moonshot (Kimi).
+<br>Powered by Claude Code, with models from Anthropic (Sonnet, Opus), Google (Gemini), MiniMax (M2.7), Zhipu AI (GLM), and Moonshot (Kimi).
 </div>

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ See [CHANGELOG.md](CHANGELOG.md) for release history.
 ## Acknowledgments
 
 - [Anthropic](https://www.anthropic.com/) for Claude Code
-- [MiniMax](https://www.minimax.io/) for MiniMax AI models (M2.7, M2.5-highspeed)
+- [MiniMax](https://www.minimax.io/) for MiniMax AI models (M3, M2.7)
 - [Sealos](https://sealos.io/) for Kubernetes platform
 - [ttyd](https://github.com/tsl0922/ttyd) for web terminal
 - [FileBrowser](https://github.com/filebrowser/filebrowser) for file management
@@ -226,5 +226,5 @@ See [CHANGELOG.md](CHANGELOG.md) for release history.
 
 <div align="center">
 <strong>100% AI-generated code.</strong> Prompted by [@fanux](https://github.com/fanux).
-<br>Powered by Claude Code, with models from Anthropic (Sonnet, Opus), Google (Gemini), MiniMax (M2.7), Zhipu AI (GLM), and Moonshot (Kimi).
+<br>Powered by Claude Code, with models from Anthropic (Sonnet, Opus), Google (Gemini), MiniMax (M3), Zhipu AI (GLM), and Moonshot (Kimi).
 </div>

--- a/__tests__/api/user/config/minimax/route.test.ts
+++ b/__tests__/api/user/config/minimax/route.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Unit tests for MiniMax Configuration API
+ *
+ * Tests the GET and POST endpoints at /api/user/config/minimax
+ */
+
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+// Mock dependencies
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    userConfig: {
+      findMany: vi.fn(),
+      upsert: vi.fn(),
+      deleteMany: vi.fn(),
+    },
+    $transaction: vi.fn((fn: (tx: unknown) => Promise<void>) =>
+      fn({
+        userConfig: {
+          upsert: vi.fn(),
+          deleteMany: vi.fn(),
+        },
+      })
+    ),
+  },
+}))
+
+vi.mock('@/lib/auth', () => ({
+  auth: vi.fn(),
+}))
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    child: () => ({
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    }),
+  },
+}))
+
+// Mock withAuth to pass through session
+vi.mock('@/lib/api-auth', () => ({
+  withAuth: (handler: Function) => {
+    return async (req: Request) => {
+      const session = { user: { id: 'test-user-id' } }
+      return handler(req, { params: Promise.resolve({}) }, session)
+    }
+  },
+}))
+
+import { prisma } from '@/lib/db'
+
+describe('GET /api/user/config/minimax', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should return MiniMax configuration when configs exist', async () => {
+    const mockConfigs = [
+      { key: 'MINIMAX_API_KEY', value: 'test-api-key' },
+      { key: 'MINIMAX_API', value: 'https://api.minimax.io/v1' },
+      { key: 'MINIMAX_MODEL', value: 'MiniMax-M2.7' },
+    ]
+    vi.mocked(prisma.userConfig.findMany).mockResolvedValue(mockConfigs as never)
+
+    const { GET } = await import('@/app/api/user/config/minimax/route')
+    const req = new Request('http://localhost/api/user/config/minimax')
+    const response = await GET(req as never, { params: Promise.resolve({}) })
+    const data = await response.json()
+
+    expect(data.apiKey).toBe('test-api-key')
+    expect(data.apiBaseUrl).toBe('https://api.minimax.io/v1')
+    expect(data.model).toBe('MiniMax-M2.7')
+  })
+
+  it('should return nulls when no configs exist', async () => {
+    vi.mocked(prisma.userConfig.findMany).mockResolvedValue([] as never)
+
+    const { GET } = await import('@/app/api/user/config/minimax/route')
+    const req = new Request('http://localhost/api/user/config/minimax')
+    const response = await GET(req as never, { params: Promise.resolve({}) })
+    const data = await response.json()
+
+    expect(data.apiKey).toBeNull()
+    expect(data.apiBaseUrl).toBeNull()
+    expect(data.model).toBeNull()
+  })
+
+  it('should return 500 on database error', async () => {
+    vi.mocked(prisma.userConfig.findMany).mockRejectedValue(new Error('DB error') as never)
+
+    const { GET } = await import('@/app/api/user/config/minimax/route')
+    const req = new Request('http://localhost/api/user/config/minimax')
+    const response = await GET(req as never, { params: Promise.resolve({}) })
+
+    expect(response.status).toBe(500)
+    const data = await response.json()
+    expect(data.error).toBe('Failed to fetch MiniMax configuration')
+  })
+})
+
+describe('POST /api/user/config/minimax', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should save MiniMax configuration successfully', async () => {
+    const { POST } = await import('@/app/api/user/config/minimax/route')
+    const req = new Request('http://localhost/api/user/config/minimax', {
+      method: 'POST',
+      body: JSON.stringify({
+        apiBaseUrl: 'https://api.minimax.io/v1',
+        apiKey: 'test-api-key',
+        model: 'MiniMax-M2.7',
+      }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+    const response = await POST(req as never, { params: Promise.resolve({}) })
+    const data = await response.json()
+
+    expect(data.success).toBe(true)
+    expect(data.message).toBe('MiniMax configuration saved successfully')
+  })
+
+  it('should reject missing API base URL', async () => {
+    const { POST } = await import('@/app/api/user/config/minimax/route')
+    const req = new Request('http://localhost/api/user/config/minimax', {
+      method: 'POST',
+      body: JSON.stringify({
+        apiBaseUrl: '',
+        apiKey: 'test-api-key',
+      }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+    const response = await POST(req as never, { params: Promise.resolve({}) })
+
+    expect(response.status).toBe(400)
+    const data = await response.json()
+    expect(data.error).toBe('API base URL is required')
+  })
+
+  it('should reject missing API key', async () => {
+    const { POST } = await import('@/app/api/user/config/minimax/route')
+    const req = new Request('http://localhost/api/user/config/minimax', {
+      method: 'POST',
+      body: JSON.stringify({
+        apiBaseUrl: 'https://api.minimax.io/v1',
+        apiKey: '',
+      }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+    const response = await POST(req as never, { params: Promise.resolve({}) })
+
+    expect(response.status).toBe(400)
+    const data = await response.json()
+    expect(data.error).toBe('API key is required')
+  })
+
+  it('should reject invalid URL format', async () => {
+    const { POST } = await import('@/app/api/user/config/minimax/route')
+    const req = new Request('http://localhost/api/user/config/minimax', {
+      method: 'POST',
+      body: JSON.stringify({
+        apiBaseUrl: 'not-a-url',
+        apiKey: 'test-api-key',
+      }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+    const response = await POST(req as never, { params: Promise.resolve({}) })
+
+    expect(response.status).toBe(400)
+    const data = await response.json()
+    expect(data.error).toBe('Invalid API base URL format')
+  })
+
+  it('should handle optional model being empty (delete config)', async () => {
+    const { POST } = await import('@/app/api/user/config/minimax/route')
+    const req = new Request('http://localhost/api/user/config/minimax', {
+      method: 'POST',
+      body: JSON.stringify({
+        apiBaseUrl: 'https://api.minimax.io/v1',
+        apiKey: 'test-api-key',
+        model: '',
+      }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+    const response = await POST(req as never, { params: Promise.resolve({}) })
+    const data = await response.json()
+
+    expect(data.success).toBe(true)
+  })
+
+  it('should save without optional model field', async () => {
+    const { POST } = await import('@/app/api/user/config/minimax/route')
+    const req = new Request('http://localhost/api/user/config/minimax', {
+      method: 'POST',
+      body: JSON.stringify({
+        apiBaseUrl: 'https://api.minimax.io/v1',
+        apiKey: 'test-api-key',
+      }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+    const response = await POST(req as never, { params: Promise.resolve({}) })
+    const data = await response.json()
+
+    expect(data.success).toBe(true)
+  })
+})

--- a/__tests__/api/user/config/minimax/route.test.ts
+++ b/__tests__/api/user/config/minimax/route.test.ts
@@ -4,7 +4,7 @@
  * Tests the GET and POST endpoints at /api/user/config/minimax
  */
 
-import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { beforeEach,describe, expect, it, vi } from 'vitest'
 
 // Mock dependencies
 vi.mock('@/lib/db', () => ({
@@ -42,7 +42,7 @@ vi.mock('@/lib/logger', () => ({
 
 // Mock withAuth to pass through session
 vi.mock('@/lib/api-auth', () => ({
-  withAuth: (handler: Function) => {
+  withAuth: (handler: (req: Request, ctx: unknown, session: unknown) => Promise<Response>) => {
     return async (req: Request) => {
       const session = { user: { id: 'test-user-id' } }
       return handler(req, { params: Promise.resolve({}) }, session)
@@ -61,7 +61,7 @@ describe('GET /api/user/config/minimax', () => {
     const mockConfigs = [
       { key: 'MINIMAX_API_KEY', value: 'test-api-key' },
       { key: 'MINIMAX_API', value: 'https://api.minimax.io/v1' },
-      { key: 'MINIMAX_MODEL', value: 'MiniMax-M2.7' },
+      { key: 'MINIMAX_MODEL', value: 'MiniMax-M3' },
     ]
     vi.mocked(prisma.userConfig.findMany).mockResolvedValue(mockConfigs as never)
 
@@ -72,7 +72,7 @@ describe('GET /api/user/config/minimax', () => {
 
     expect(data.apiKey).toBe('test-api-key')
     expect(data.apiBaseUrl).toBe('https://api.minimax.io/v1')
-    expect(data.model).toBe('MiniMax-M2.7')
+    expect(data.model).toBe('MiniMax-M3')
   })
 
   it('should return nulls when no configs exist', async () => {
@@ -113,7 +113,7 @@ describe('POST /api/user/config/minimax', () => {
       body: JSON.stringify({
         apiBaseUrl: 'https://api.minimax.io/v1',
         apiKey: 'test-api-key',
-        model: 'MiniMax-M2.7',
+        model: 'MiniMax-M3',
       }),
       headers: { 'Content-Type': 'application/json' },
     })

--- a/__tests__/integration/minimax-provider.test.ts
+++ b/__tests__/integration/minimax-provider.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Integration tests for MiniMax provider
+ *
+ * Tests the end-to-end flow of MiniMax configuration:
+ * - API endpoint saves config to database
+ * - loadEnvVarsForSandbox reads config and maps to env vars
+ * - Settings UI interacts with API correctly
+ *
+ * These tests require a running database and should be run with:
+ *   DATABASE_URL=... vitest run __tests__/integration/
+ */
+
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+// Mock prisma with in-memory store
+const configStore: Map<string, { key: string; value: string; category: string; isSecret: boolean }> =
+  new Map()
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    userConfig: {
+      findMany: vi.fn(async ({ where }: { where: { userId: string; key: { in: string[] } } }) => {
+        return Array.from(configStore.values()).filter(
+          (c) => where.key.in.includes(c.key)
+        )
+      }),
+      upsert: vi.fn(
+        async ({
+          create,
+          update,
+          where,
+        }: {
+          create: { key: string; value: string; category: string; isSecret: boolean }
+          update: { value: string }
+          where: { userId_key: { key: string } }
+        }) => {
+          const existing = configStore.get(where.userId_key.key)
+          if (existing) {
+            existing.value = update.value
+            configStore.set(where.userId_key.key, existing)
+          } else {
+            configStore.set(create.key, create)
+          }
+        }
+      ),
+      deleteMany: vi.fn(async ({ where }: { where: { key: string } }) => {
+        configStore.delete(where.key)
+      }),
+    },
+    $transaction: vi.fn(async (fn: (tx: unknown) => Promise<void>) => {
+      const tx = {
+        userConfig: {
+          upsert: vi.fn(
+            async ({
+              create,
+              update,
+              where,
+            }: {
+              create: { key: string; value: string; category: string; isSecret: boolean }
+              update: { value: string }
+              where: { userId_key: { key: string } }
+            }) => {
+              const existing = configStore.get(where.userId_key.key)
+              if (existing) {
+                existing.value = update.value
+                configStore.set(where.userId_key.key, existing)
+              } else {
+                configStore.set(create.key, create)
+              }
+            }
+          ),
+          deleteMany: vi.fn(async ({ where }: { where: { key: string } }) => {
+            configStore.delete(where.key)
+          }),
+        },
+      }
+      await fn(tx)
+    }),
+  },
+}))
+
+vi.mock('@/lib/auth', () => ({
+  auth: vi.fn(),
+}))
+
+vi.mock('@/lib/env', () => ({
+  env: {
+    AIPROXY_ENDPOINT: undefined,
+    ANTHROPIC_BASE_URL: undefined,
+    ANTHROPIC_MODEL: undefined,
+    ANTHROPIC_SMALL_FAST_MODEL: undefined,
+  },
+}))
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    child: () => ({
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    }),
+  },
+}))
+
+vi.mock('@/lib/api-auth', () => ({
+  withAuth: (handler: Function) => {
+    return async (req: Request) => {
+      const session = { user: { id: 'integration-test-user' } }
+      return handler(req, { params: Promise.resolve({}) }, session)
+    }
+  },
+}))
+
+describe('MiniMax Provider Integration', () => {
+  beforeEach(() => {
+    configStore.clear()
+    vi.clearAllMocks()
+  })
+
+  it('should save MiniMax config via API and load it for sandbox', async () => {
+    // Step 1: Save config via POST endpoint
+    const { POST } = await import('@/app/api/user/config/minimax/route')
+    const saveReq = new Request('http://localhost/api/user/config/minimax', {
+      method: 'POST',
+      body: JSON.stringify({
+        apiBaseUrl: 'https://api.minimax.io/v1',
+        apiKey: 'integration-test-key',
+        model: 'MiniMax-M2.7',
+      }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+    const saveResponse = await POST(saveReq as never, { params: Promise.resolve({}) })
+    const saveData = await saveResponse.json()
+
+    expect(saveData.success).toBe(true)
+
+    // Step 2: Verify config was stored
+    expect(configStore.has('MINIMAX_API_KEY')).toBe(true)
+    expect(configStore.has('MINIMAX_API')).toBe(true)
+    expect(configStore.has('MINIMAX_MODEL')).toBe(true)
+
+    // Step 3: Load config via GET endpoint
+    const { GET } = await import('@/app/api/user/config/minimax/route')
+    const getReq = new Request('http://localhost/api/user/config/minimax')
+    const getResponse = await GET(getReq as never, { params: Promise.resolve({}) })
+    const getData = await getResponse.json()
+
+    expect(getData.apiKey).toBe('integration-test-key')
+    expect(getData.apiBaseUrl).toBe('https://api.minimax.io/v1')
+    expect(getData.model).toBe('MiniMax-M2.7')
+  })
+
+  it('should coexist with Anthropic config without interference', async () => {
+    // Set up Anthropic config
+    configStore.set('ANTHROPIC_API_KEY', {
+      key: 'ANTHROPIC_API_KEY',
+      value: 'sk-ant-existing',
+      category: 'anthropic',
+      isSecret: true,
+    })
+    configStore.set('ANTHROPIC_API', {
+      key: 'ANTHROPIC_API',
+      value: 'https://api.anthropic.com',
+      category: 'anthropic',
+      isSecret: false,
+    })
+
+    // Save MiniMax config via API
+    const { POST } = await import('@/app/api/user/config/minimax/route')
+    const saveReq = new Request('http://localhost/api/user/config/minimax', {
+      method: 'POST',
+      body: JSON.stringify({
+        apiBaseUrl: 'https://api.minimax.io/v1',
+        apiKey: 'minimax-key',
+      }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+    await POST(saveReq as never, { params: Promise.resolve({}) })
+
+    // Verify Anthropic config is untouched
+    expect(configStore.get('ANTHROPIC_API_KEY')?.value).toBe('sk-ant-existing')
+    expect(configStore.get('ANTHROPIC_API')?.value).toBe('https://api.anthropic.com')
+
+    // Verify MiniMax config exists
+    expect(configStore.get('MINIMAX_API_KEY')?.value).toBe('minimax-key')
+  })
+
+  it('should store MiniMax API key as secret', async () => {
+    const { POST } = await import('@/app/api/user/config/minimax/route')
+    const req = new Request('http://localhost/api/user/config/minimax', {
+      method: 'POST',
+      body: JSON.stringify({
+        apiBaseUrl: 'https://api.minimax.io/v1',
+        apiKey: 'secret-key',
+      }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+    await POST(req as never, { params: Promise.resolve({}) })
+
+    const apiKeyConfig = configStore.get('MINIMAX_API_KEY')
+    expect(apiKeyConfig?.isSecret).toBe(true)
+    expect(apiKeyConfig?.category).toBe('minimax')
+
+    const apiUrlConfig = configStore.get('MINIMAX_API')
+    expect(apiUrlConfig?.isSecret).toBe(false)
+  })
+})

--- a/__tests__/integration/minimax-provider.test.ts
+++ b/__tests__/integration/minimax-provider.test.ts
@@ -10,7 +10,7 @@
  *   DATABASE_URL=... vitest run __tests__/integration/
  */
 
-import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { beforeEach,describe, expect, it, vi } from 'vitest'
 
 // Mock prisma with in-memory store
 const configStore: Map<string, { key: string; value: string; category: string; isSecret: boolean }> =
@@ -104,7 +104,7 @@ vi.mock('@/lib/logger', () => ({
 }))
 
 vi.mock('@/lib/api-auth', () => ({
-  withAuth: (handler: Function) => {
+  withAuth: (handler: (req: Request, ctx: unknown, session: unknown) => Promise<Response>) => {
     return async (req: Request) => {
       const session = { user: { id: 'integration-test-user' } }
       return handler(req, { params: Promise.resolve({}) }, session)
@@ -126,7 +126,7 @@ describe('MiniMax Provider Integration', () => {
       body: JSON.stringify({
         apiBaseUrl: 'https://api.minimax.io/v1',
         apiKey: 'integration-test-key',
-        model: 'MiniMax-M2.7',
+        model: 'MiniMax-M3',
       }),
       headers: { 'Content-Type': 'application/json' },
     })
@@ -148,7 +148,7 @@ describe('MiniMax Provider Integration', () => {
 
     expect(getData.apiKey).toBe('integration-test-key')
     expect(getData.apiBaseUrl).toBe('https://api.minimax.io/v1')
-    expect(getData.model).toBe('MiniMax-M2.7')
+    expect(getData.model).toBe('MiniMax-M3')
   })
 
   it('should coexist with Anthropic config without interference', async () => {

--- a/__tests__/services/aiproxy.test.ts
+++ b/__tests__/services/aiproxy.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Unit tests for loadEnvVarsForSandbox service
+ *
+ * Tests that MiniMax env vars are correctly loaded and mapped
+ */
+
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+// Mock dependencies
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    userConfig: {
+      findMany: vi.fn(),
+    },
+  },
+}))
+
+vi.mock('@/lib/env', () => ({
+  env: {
+    AIPROXY_ENDPOINT: undefined,
+    ANTHROPIC_BASE_URL: undefined,
+    ANTHROPIC_MODEL: undefined,
+    ANTHROPIC_SMALL_FAST_MODEL: undefined,
+  },
+}))
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    child: () => ({
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    }),
+  },
+}))
+
+import { prisma } from '@/lib/db'
+
+describe('loadEnvVarsForSandbox', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should load MiniMax env vars alongside Anthropic', async () => {
+    const mockConfigs = [
+      { key: 'ANTHROPIC_API_KEY', value: 'sk-ant-test' },
+      { key: 'ANTHROPIC_API', value: 'https://api.anthropic.com' },
+      { key: 'ANTHROPIC_MODEL', value: 'claude-sonnet-4-5-20250929' },
+      { key: 'ANTHROPIC_SMALL_FAST_MODEL', value: 'claude-3-5-haiku-20241022' },
+      { key: 'MINIMAX_API_KEY', value: 'minimax-test-key' },
+      { key: 'MINIMAX_API', value: 'https://api.minimax.io/v1' },
+      { key: 'MINIMAX_MODEL', value: 'MiniMax-M2.7' },
+    ]
+    vi.mocked(prisma.userConfig.findMany).mockResolvedValue(mockConfigs as never)
+
+    const { loadEnvVarsForSandbox } = await import('@/lib/services/aiproxy')
+    const envVars = await loadEnvVarsForSandbox('test-user-id')
+
+    // Anthropic vars
+    expect(envVars.ANTHROPIC_AUTH_TOKEN).toBe('sk-ant-test')
+    expect(envVars.ANTHROPIC_BASE_URL).toBe('https://api.anthropic.com')
+    expect(envVars.ANTHROPIC_MODEL).toBe('claude-sonnet-4-5-20250929')
+    expect(envVars.ANTHROPIC_SMALL_FAST_MODEL).toBe('claude-3-5-haiku-20241022')
+
+    // MiniMax vars
+    expect(envVars.MINIMAX_API_KEY).toBe('minimax-test-key')
+    expect(envVars.MINIMAX_BASE_URL).toBe('https://api.minimax.io/v1')
+    expect(envVars.MINIMAX_MODEL).toBe('MiniMax-M2.7')
+  })
+
+  it('should return only Anthropic vars when no MiniMax config exists', async () => {
+    const mockConfigs = [
+      { key: 'ANTHROPIC_API_KEY', value: 'sk-ant-test' },
+      { key: 'ANTHROPIC_API', value: 'https://api.anthropic.com' },
+    ]
+    vi.mocked(prisma.userConfig.findMany).mockResolvedValue(mockConfigs as never)
+
+    const { loadEnvVarsForSandbox } = await import('@/lib/services/aiproxy')
+    const envVars = await loadEnvVarsForSandbox('test-user-id')
+
+    expect(envVars.ANTHROPIC_AUTH_TOKEN).toBe('sk-ant-test')
+    expect(envVars.MINIMAX_API_KEY).toBeUndefined()
+    expect(envVars.MINIMAX_BASE_URL).toBeUndefined()
+    expect(envVars.MINIMAX_MODEL).toBeUndefined()
+  })
+
+  it('should return only MiniMax vars when no Anthropic config exists', async () => {
+    const mockConfigs = [
+      { key: 'MINIMAX_API_KEY', value: 'minimax-test-key' },
+      { key: 'MINIMAX_API', value: 'https://api.minimax.io/v1' },
+      { key: 'MINIMAX_MODEL', value: 'MiniMax-M2.5-highspeed' },
+    ]
+    vi.mocked(prisma.userConfig.findMany).mockResolvedValue(mockConfigs as never)
+
+    const { loadEnvVarsForSandbox } = await import('@/lib/services/aiproxy')
+    const envVars = await loadEnvVarsForSandbox('test-user-id')
+
+    expect(envVars.ANTHROPIC_AUTH_TOKEN).toBeUndefined()
+    expect(envVars.MINIMAX_API_KEY).toBe('minimax-test-key')
+    expect(envVars.MINIMAX_BASE_URL).toBe('https://api.minimax.io/v1')
+    expect(envVars.MINIMAX_MODEL).toBe('MiniMax-M2.5-highspeed')
+  })
+
+  it('should return empty object when no configs exist', async () => {
+    vi.mocked(prisma.userConfig.findMany).mockResolvedValue([] as never)
+
+    const { loadEnvVarsForSandbox } = await import('@/lib/services/aiproxy')
+    const envVars = await loadEnvVarsForSandbox('test-user-id')
+
+    expect(Object.keys(envVars)).toHaveLength(0)
+  })
+
+  it('should query database with MiniMax keys included', async () => {
+    vi.mocked(prisma.userConfig.findMany).mockResolvedValue([] as never)
+
+    const { loadEnvVarsForSandbox } = await import('@/lib/services/aiproxy')
+    await loadEnvVarsForSandbox('test-user-id')
+
+    expect(prisma.userConfig.findMany).toHaveBeenCalledWith({
+      where: {
+        userId: 'test-user-id',
+        key: {
+          in: expect.arrayContaining([
+            'MINIMAX_API_KEY',
+            'MINIMAX_API',
+            'MINIMAX_MODEL',
+          ]),
+        },
+      },
+    })
+  })
+})

--- a/__tests__/services/aiproxy.test.ts
+++ b/__tests__/services/aiproxy.test.ts
@@ -4,7 +4,7 @@
  * Tests that MiniMax env vars are correctly loaded and mapped
  */
 
-import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { beforeEach,describe, expect, it, vi } from 'vitest'
 
 // Mock dependencies
 vi.mock('@/lib/db', () => ({
@@ -50,7 +50,7 @@ describe('loadEnvVarsForSandbox', () => {
       { key: 'ANTHROPIC_SMALL_FAST_MODEL', value: 'claude-3-5-haiku-20241022' },
       { key: 'MINIMAX_API_KEY', value: 'minimax-test-key' },
       { key: 'MINIMAX_API', value: 'https://api.minimax.io/v1' },
-      { key: 'MINIMAX_MODEL', value: 'MiniMax-M2.7' },
+      { key: 'MINIMAX_MODEL', value: 'MiniMax-M3' },
     ]
     vi.mocked(prisma.userConfig.findMany).mockResolvedValue(mockConfigs as never)
 
@@ -66,7 +66,7 @@ describe('loadEnvVarsForSandbox', () => {
     // MiniMax vars
     expect(envVars.MINIMAX_API_KEY).toBe('minimax-test-key')
     expect(envVars.MINIMAX_BASE_URL).toBe('https://api.minimax.io/v1')
-    expect(envVars.MINIMAX_MODEL).toBe('MiniMax-M2.7')
+    expect(envVars.MINIMAX_MODEL).toBe('MiniMax-M3')
   })
 
   it('should return only Anthropic vars when no MiniMax config exists', async () => {
@@ -89,7 +89,7 @@ describe('loadEnvVarsForSandbox', () => {
     const mockConfigs = [
       { key: 'MINIMAX_API_KEY', value: 'minimax-test-key' },
       { key: 'MINIMAX_API', value: 'https://api.minimax.io/v1' },
-      { key: 'MINIMAX_MODEL', value: 'MiniMax-M2.5-highspeed' },
+      { key: 'MINIMAX_MODEL', value: 'MiniMax-M2.7' },
     ]
     vi.mocked(prisma.userConfig.findMany).mockResolvedValue(mockConfigs as never)
 
@@ -99,7 +99,7 @@ describe('loadEnvVarsForSandbox', () => {
     expect(envVars.ANTHROPIC_AUTH_TOKEN).toBeUndefined()
     expect(envVars.MINIMAX_API_KEY).toBe('minimax-test-key')
     expect(envVars.MINIMAX_BASE_URL).toBe('https://api.minimax.io/v1')
-    expect(envVars.MINIMAX_MODEL).toBe('MiniMax-M2.5-highspeed')
+    expect(envVars.MINIMAX_MODEL).toBe('MiniMax-M2.7')
   })
 
   it('should return empty object when no configs exist', async () => {

--- a/app/api/user/config/minimax/route.ts
+++ b/app/api/user/config/minimax/route.ts
@@ -1,0 +1,187 @@
+/**
+ * MiniMax Configuration API
+ *
+ * GET /api/user/config/minimax
+ * - Get MiniMax API configuration
+ * - Returns: { apiKey: string | null, apiBaseUrl: string | null, model: string | null }
+ *
+ * POST /api/user/config/minimax
+ * - Save MiniMax API configuration
+ * - Body: { apiBaseUrl: string, apiKey: string, model?: string }
+ * - Returns: { success: true }
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+
+import { type RouteContext, withAuth } from '@/lib/api-auth'
+import { prisma } from '@/lib/db'
+import { logger as baseLogger } from '@/lib/logger'
+
+const logger = baseLogger.child({ module: 'api/user/config/minimax' })
+
+const MINIMAX_API_KEY = 'MINIMAX_API_KEY'
+const MINIMAX_API = 'MINIMAX_API'
+const MINIMAX_MODEL = 'MINIMAX_MODEL'
+
+type GetMiniMaxConfigResponse =
+  | { error: string }
+  | {
+      apiKey: string | null
+      apiBaseUrl: string | null
+      model: string | null
+    }
+
+/**
+ * GET /api/user/config/minimax
+ * Get MiniMax API configuration
+ */
+export const GET = withAuth<GetMiniMaxConfigResponse>(
+  async (_req: NextRequest, _context: RouteContext, session) => {
+    try {
+      const configs = await prisma.userConfig.findMany({
+        where: {
+          userId: session.user.id,
+          key: {
+            in: [MINIMAX_API_KEY, MINIMAX_API, MINIMAX_MODEL],
+          },
+        },
+      })
+
+      const apiKey = configs.find((c) => c.key === MINIMAX_API_KEY)?.value || null
+      const apiBaseUrl = configs.find((c) => c.key === MINIMAX_API)?.value || null
+      const model = configs.find((c) => c.key === MINIMAX_MODEL)?.value || null
+
+      return NextResponse.json({
+        apiKey,
+        apiBaseUrl,
+        model,
+      })
+    } catch (error) {
+      logger.error(`Failed to fetch MiniMax config: ${error}`)
+      return NextResponse.json(
+        { error: 'Failed to fetch MiniMax configuration' },
+        { status: 500 }
+      )
+    }
+  }
+)
+
+/**
+ * POST /api/user/config/minimax
+ * Save MiniMax API configuration
+ */
+interface SaveMiniMaxConfigRequest {
+  apiBaseUrl: string
+  apiKey: string
+  model?: string
+}
+
+type PostMiniMaxConfigResponse = { error: string } | { success: true; message: string }
+
+export const POST = withAuth<PostMiniMaxConfigResponse>(
+  async (req: NextRequest, _context: RouteContext, session) => {
+    try {
+      const body: SaveMiniMaxConfigRequest = await req.json()
+
+      // Validate inputs
+      if (!body.apiBaseUrl || typeof body.apiBaseUrl !== 'string') {
+        return NextResponse.json({ error: 'API base URL is required' }, { status: 400 })
+      }
+
+      if (!body.apiKey || typeof body.apiKey !== 'string') {
+        return NextResponse.json({ error: 'API key is required' }, { status: 400 })
+      }
+
+      // Validate URL format
+      try {
+        new URL(body.apiBaseUrl)
+      } catch {
+        return NextResponse.json({ error: 'Invalid API base URL format' }, { status: 400 })
+      }
+
+      // Execute all operations in a transaction
+      await prisma.$transaction(async (tx) => {
+        // Save API key
+        await tx.userConfig.upsert({
+          where: {
+            userId_key: {
+              userId: session.user.id,
+              key: MINIMAX_API_KEY,
+            },
+          },
+          create: {
+            userId: session.user.id,
+            key: MINIMAX_API_KEY,
+            value: body.apiKey,
+            category: 'minimax',
+            isSecret: true,
+          },
+          update: {
+            value: body.apiKey,
+          },
+        })
+
+        // Save API base URL
+        await tx.userConfig.upsert({
+          where: {
+            userId_key: {
+              userId: session.user.id,
+              key: MINIMAX_API,
+            },
+          },
+          create: {
+            userId: session.user.id,
+            key: MINIMAX_API,
+            value: body.apiBaseUrl,
+            category: 'minimax',
+            isSecret: false,
+          },
+          update: {
+            value: body.apiBaseUrl,
+          },
+        })
+
+        // Save or clear model if provided
+        if (body.model !== undefined) {
+          if (body.model === '' || body.model === null) {
+            await tx.userConfig.deleteMany({
+              where: {
+                userId: session.user.id,
+                key: MINIMAX_MODEL,
+              },
+            })
+          } else {
+            await tx.userConfig.upsert({
+              where: {
+                userId_key: {
+                  userId: session.user.id,
+                  key: MINIMAX_MODEL,
+                },
+              },
+              create: {
+                userId: session.user.id,
+                key: MINIMAX_MODEL,
+                value: body.model,
+                category: 'minimax',
+                isSecret: false,
+              },
+              update: {
+                value: body.model,
+              },
+            })
+          }
+        }
+      })
+
+      logger.info(`MiniMax configuration saved for user ${session.user.id}`)
+
+      return NextResponse.json({
+        success: true,
+        message: 'MiniMax configuration saved successfully',
+      })
+    } catch (error) {
+      logger.error(`Failed to save MiniMax config: ${error}`)
+      return NextResponse.json({ error: 'Failed to save MiniMax configuration' }, { status: 500 })
+    }
+  }
+)

--- a/components/dialog/settings-dialog.tsx
+++ b/components/dialog/settings-dialog.tsx
@@ -30,7 +30,7 @@ import { useSealos } from '@/provider/sealos';
 interface SettingsDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  defaultTab?: 'system-prompt' | 'kubeconfig' | 'anthropic' | 'github';
+  defaultTab?: 'system-prompt' | 'kubeconfig' | 'anthropic' | 'minimax' | 'github';
 }
 
 const DEFAULT_SYSTEM_PROMPT = `You are an AI full-stack developer working in a Next.js environment.
@@ -61,7 +61,7 @@ const DEFAULT_SYSTEM_PROMPT = `You are an AI full-stack developer working in a N
 - Optimize for performance and SEO
 - Follow modern React patterns and best practices`;
 
-type TabType = 'system-prompt' | 'kubeconfig' | 'anthropic' | 'github';
+type TabType = 'system-prompt' | 'kubeconfig' | 'anthropic' | 'minimax' | 'github';
 
 export default function SettingsDialog({
   open,
@@ -90,6 +90,13 @@ export default function SettingsDialog({
   const [isAnthropicLoading, setIsAnthropicLoading] = useState(false);
   const [isAnthropicInitialLoading, setIsAnthropicInitialLoading] = useState(true);
 
+  // MiniMax state
+  const [minimaxApiKey, setMinimaxApiKey] = useState('');
+  const [minimaxApiBaseUrl, setMinimaxApiBaseUrl] = useState('');
+  const [minimaxModel, setMinimaxModel] = useState('');
+  const [isMinimaxLoading, setIsMinimaxLoading] = useState(false);
+  const [isMinimaxInitialLoading, setIsMinimaxInitialLoading] = useState(true);
+
   // GitHub state
   const [githubInstallation, setGithubInstallation] = useState<GitHubInstallation | null>(null);
   const [isGithubLoading, setIsGithubLoading] = useState(false);
@@ -99,6 +106,7 @@ export default function SettingsDialog({
   const [showSystemPromptConfirm, setShowSystemPromptConfirm] = useState(false);
   const [showSystemPromptResetConfirm, setShowSystemPromptResetConfirm] = useState(false);
   const [showAnthropicConfirm, setShowAnthropicConfirm] = useState(false);
+  const [showMinimaxConfirm, setShowMinimaxConfirm] = useState(false);
 
   // Load data when dialog opens
   useEffect(() => {
@@ -108,6 +116,7 @@ export default function SettingsDialog({
         loadKubeconfig();
       }
       loadAnthropicConfig();
+      loadMinimaxConfig();
       loadGithubStatus();
     }
   }, [open, isSealos]);
@@ -167,6 +176,23 @@ export default function SettingsDialog({
       console.error('Failed to load Anthropic config:', error);
     } finally {
       setIsAnthropicInitialLoading(false);
+    }
+  };
+
+  const loadMinimaxConfig = async () => {
+    try {
+      const data = await fetchClient.GET<{
+        apiKey: string | null;
+        apiBaseUrl: string | null;
+        model: string | null;
+      }>('/api/user/config/minimax');
+      setMinimaxApiKey(data.apiKey || '');
+      setMinimaxApiBaseUrl(data.apiBaseUrl || '');
+      setMinimaxModel(data.model || '');
+    } catch (error) {
+      console.error('Failed to load MiniMax config:', error);
+    } finally {
+      setIsMinimaxInitialLoading(false);
     }
   };
 
@@ -269,6 +295,35 @@ export default function SettingsDialog({
     }
   };
 
+  const handleSaveMinimaxConfig = () => {
+    if (!minimaxApiKey.trim() || !minimaxApiBaseUrl.trim()) {
+      toast.error('Both API key and base URL are required');
+      return;
+    }
+    setShowMinimaxConfirm(true);
+  };
+
+  const handleConfirmSaveMinimaxConfig = async () => {
+    setShowMinimaxConfirm(false);
+    setIsMinimaxLoading(true);
+    try {
+      await fetchClient.POST('/api/user/config/minimax', {
+        apiKey: minimaxApiKey,
+        apiBaseUrl: minimaxApiBaseUrl,
+        model: minimaxModel.trim() || undefined,
+      });
+      toast.success('MiniMax configuration saved successfully');
+      onOpenChange(false);
+    } catch (error: unknown) {
+      console.error('Failed to save MiniMax config:', error);
+      toast.error(
+        error instanceof Error ? error.message : 'Failed to save MiniMax configuration'
+      );
+    } finally {
+      setIsMinimaxLoading(false);
+    }
+  };
+
   const handleResetSystemPrompt = () => {
     setShowSystemPromptResetConfirm(true);
   };
@@ -355,7 +410,7 @@ export default function SettingsDialog({
             className="h-full flex flex-col"
           >
             <TabsList
-              className={`shrink-0 grid w-full ${isSealos ? 'grid-cols-3' : 'grid-cols-4'} bg-secondary border-border rounded-lg`}
+              className={`shrink-0 grid w-full ${isSealos ? 'grid-cols-4' : 'grid-cols-5'} bg-secondary border-border rounded-lg`}
             >
               <TabsTrigger
                 value="system-prompt"
@@ -379,6 +434,13 @@ export default function SettingsDialog({
               >
                 <MdTerminal className="mr-2 h-4 w-4" />
                 Anthropic
+              </TabsTrigger>
+              <TabsTrigger
+                value="minimax"
+                className="data-[state=active]:bg-primary data-[state=active]:text-foreground text-muted-foreground hover:text-foreground"
+              >
+                <MdTerminal className="mr-2 h-4 w-4" />
+                MiniMax
               </TabsTrigger>
               <TabsTrigger
                 value="github"
@@ -596,6 +658,93 @@ export default function SettingsDialog({
                 </div>
               </TabsContent>
 
+              {/* MiniMax Tab */}
+              <TabsContent value="minimax" className="mt-0 h-full overflow-y-auto">
+                <div className="space-y-4 pb-4">
+                  <div className="space-y-2">
+                    <Label
+                      htmlFor="minimax-api-base-url-dialog"
+                      className="text-foreground text-sm font-medium"
+                    >
+                      API Base URL
+                    </Label>
+                    <Input
+                      id="minimax-api-base-url-dialog"
+                      type="url"
+                      value={minimaxApiBaseUrl}
+                      onChange={(e) => setMinimaxApiBaseUrl(e.target.value)}
+                      disabled={isMinimaxInitialLoading}
+                      className="bg-input border-border text-foreground placeholder:text-muted-foreground disabled:opacity-50 rounded-md focus:ring-2 focus:ring-ring focus:border-ring"
+                      placeholder="https://api.minimax.io/v1"
+                    />
+                    <p className="text-xs text-muted-foreground mt-0">
+                      The base URL for MiniMax API (default: https://api.minimax.io/v1). MiniMax
+                      provides an OpenAI-compatible API.
+                    </p>
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label
+                      htmlFor="minimax-api-key-dialog"
+                      className="text-foreground text-sm font-medium"
+                    >
+                      API Key
+                    </Label>
+                    <Input
+                      id="minimax-api-key-dialog"
+                      type="password"
+                      value={minimaxApiKey}
+                      onChange={(e) => setMinimaxApiKey(e.target.value)}
+                      disabled={isMinimaxInitialLoading}
+                      className="bg-input border-border text-foreground placeholder:text-muted-foreground font-mono disabled:opacity-50 rounded-md focus:ring-2 focus:ring-ring focus:border-ring"
+                      placeholder="eyJh..."
+                    />
+                    <p className="text-xs text-muted-foreground mt-0">
+                      Your MiniMax API key. This will be stored securely and injected as
+                      MINIMAX_API_KEY in sandboxes.
+                    </p>
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label
+                      htmlFor="minimax-model-dialog"
+                      className="text-foreground text-sm font-medium"
+                    >
+                      Default Model (Optional)
+                    </Label>
+                    <Input
+                      id="minimax-model-dialog"
+                      type="text"
+                      value={minimaxModel}
+                      onChange={(e) => setMinimaxModel(e.target.value)}
+                      disabled={isMinimaxInitialLoading}
+                      className="bg-input border-border text-foreground placeholder:text-muted-foreground font-mono disabled:opacity-50 rounded-md focus:ring-2 focus:ring-ring focus:border-ring"
+                      placeholder="MiniMax-M2.7"
+                    />
+                    <p className="text-xs text-muted-foreground mt-0">
+                      Default model to use (e.g., MiniMax-M2.7, MiniMax-M2.5-highspeed). This will
+                      be injected as MINIMAX_MODEL in sandboxes.
+                    </p>
+                  </div>
+
+                  <div className="flex gap-2 pt-2">
+                    <Button
+                      onClick={handleSaveMinimaxConfig}
+                      disabled={
+                        isMinimaxLoading ||
+                        isMinimaxInitialLoading ||
+                        !minimaxApiKey.trim() ||
+                        !minimaxApiBaseUrl.trim()
+                      }
+                      className="bg-primary hover:bg-primary/90 text-primary-foreground"
+                    >
+                      <MdSave className="mr-2 h-4 w-4" />
+                      {isMinimaxLoading ? 'Saving...' : 'Save Configuration'}
+                    </Button>
+                  </div>
+                </div>
+              </TabsContent>
+
               {/* GitHub Tab */}
               <TabsContent value="github" className="mt-0 h-full overflow-y-auto">
                 <div className="space-y-4 pb-4">
@@ -718,6 +867,32 @@ export default function SettingsDialog({
                 className="bg-primary hover:bg-primary/90 text-primary-foreground"
               >
                 Reset to Default
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+
+        {/* MiniMax Config Confirmation Dialog */}
+        <AlertDialog open={showMinimaxConfirm} onOpenChange={setShowMinimaxConfirm}>
+          <AlertDialogContent className="bg-card border-border text-foreground">
+            <AlertDialogHeader>
+              <AlertDialogTitle className="text-foreground">
+                Confirm Save MiniMax Configuration
+              </AlertDialogTitle>
+              <AlertDialogDescription className="text-muted-foreground">
+                These changes won&apos;t take effect until you manually restart the application.
+                Save now?
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel className="border-border text-muted-foreground hover:text-foreground hover:bg-accent">
+                Cancel
+              </AlertDialogCancel>
+              <AlertDialogAction
+                onClick={handleConfirmSaveMinimaxConfig}
+                className="bg-primary hover:bg-primary/90 text-primary-foreground"
+              >
+                Save Configuration
               </AlertDialogAction>
             </AlertDialogFooter>
           </AlertDialogContent>

--- a/components/dialog/settings-dialog.tsx
+++ b/components/dialog/settings-dialog.tsx
@@ -719,10 +719,10 @@ export default function SettingsDialog({
                       onChange={(e) => setMinimaxModel(e.target.value)}
                       disabled={isMinimaxInitialLoading}
                       className="bg-input border-border text-foreground placeholder:text-muted-foreground font-mono disabled:opacity-50 rounded-md focus:ring-2 focus:ring-ring focus:border-ring"
-                      placeholder="MiniMax-M2.7"
+                      placeholder="MiniMax-M3"
                     />
                     <p className="text-xs text-muted-foreground mt-0">
-                      Default model to use (e.g., MiniMax-M2.7, MiniMax-M2.5-highspeed). This will
+                      Default model to use (e.g., MiniMax-M3, MiniMax-M2.7). This will
                       be injected as MINIMAX_MODEL in sandboxes.
                     </p>
                   </div>

--- a/lib/services/aiproxy.ts
+++ b/lib/services/aiproxy.ts
@@ -86,14 +86,22 @@ export async function createAiproxyToken(
 /**
  * Load environment variables for sandbox from user config
  * @param userId - User ID
- * @returns Environment variables object with ANTHROPIC_BASE_URL, ANTHROPIC_AUTH_TOKEN, and model configs
+ * @returns Environment variables object with ANTHROPIC_BASE_URL, ANTHROPIC_AUTH_TOKEN, MiniMax configs, and model configs
  */
 export async function loadEnvVarsForSandbox(userId: string): Promise<Record<string, string>> {
   const userConfig = await prisma.userConfig.findMany({
     where: {
       userId,
       key: {
-        in: ['ANTHROPIC_API_KEY', 'ANTHROPIC_API', 'ANTHROPIC_MODEL', 'ANTHROPIC_SMALL_FAST_MODEL'],
+        in: [
+          'ANTHROPIC_API_KEY',
+          'ANTHROPIC_API',
+          'ANTHROPIC_MODEL',
+          'ANTHROPIC_SMALL_FAST_MODEL',
+          'MINIMAX_API_KEY',
+          'MINIMAX_API',
+          'MINIMAX_MODEL',
+        ],
       },
     },
   })
@@ -122,6 +130,24 @@ export async function loadEnvVarsForSandbox(userId: string): Promise<Record<stri
   const smallFastModel = userConfig.find((config) => config.key === 'ANTHROPIC_SMALL_FAST_MODEL')
   if (smallFastModel?.value) {
     envVars.ANTHROPIC_SMALL_FAST_MODEL = smallFastModel.value
+  }
+
+  // Find MINIMAX_API_KEY
+  const minimaxApiKey = userConfig.find((config) => config.key === 'MINIMAX_API_KEY')
+  if (minimaxApiKey?.value) {
+    envVars.MINIMAX_API_KEY = minimaxApiKey.value
+  }
+
+  // Find MINIMAX_API and map to MINIMAX_BASE_URL
+  const minimaxApiBaseUrl = userConfig.find((config) => config.key === 'MINIMAX_API')
+  if (minimaxApiBaseUrl?.value) {
+    envVars.MINIMAX_BASE_URL = minimaxApiBaseUrl.value
+  }
+
+  // Find MINIMAX_MODEL
+  const minimaxModel = userConfig.find((config) => config.key === 'MINIMAX_MODEL')
+  if (minimaxModel?.value) {
+    envVars.MINIMAX_MODEL = minimaxModel.value
   }
 
   return envVars

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,15 @@
+import { resolve } from 'path'
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['__tests__/**/*.test.ts'],
+  },
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, '.'),
+    },
+  },
+})


### PR DESCRIPTION
## Summary

Add [MiniMax AI](https://www.minimax.io/) as a first-class LLM provider alongside Anthropic. MiniMax provides an OpenAI-compatible API with models like **MiniMax-M2.7** (latest, 1M context) and **MiniMax-M2.5-highspeed** (204K context, fast inference).

### Changes

- **API Route** (`app/api/user/config/minimax/route.ts`): New GET/POST endpoints for MiniMax configuration management, following the same pattern as the Anthropic config endpoint
- **Settings UI** (`components/dialog/settings-dialog.tsx`): New "MiniMax" tab in the Settings dialog with fields for API Base URL, API Key, and Default Model
- **Sandbox Env Injection** (`lib/services/aiproxy.ts`): `loadEnvVarsForSandbox()` now loads `MINIMAX_API_KEY`, `MINIMAX_BASE_URL`, and `MINIMAX_MODEL` environment variables into sandboxes
- **Environment Template** (`.env.template`): Added MiniMax configuration section with default base URL
- **Tests**: Added 9 unit tests for the API route, 5 unit tests for the service layer, and 3 integration tests
- **README**: Added MiniMax to acknowledgments section

### How It Works

1. Users configure MiniMax credentials in Settings → MiniMax tab
2. Config is stored in `UserConfig` table with `category: 'minimax'`
3. On sandbox creation, MiniMax env vars are injected alongside Anthropic vars
4. Claude Code in the sandbox can use MiniMax models via the OpenAI-compatible API

### MiniMax API

- Base URL: `https://api.minimax.io/v1`
- Models: `MiniMax-M2.7`, `MiniMax-M2.5`, `MiniMax-M2.5-highspeed`
- OpenAI-compatible chat completions API

## Test Plan

- [ ] Verify MiniMax tab appears in Settings dialog
- [ ] Test saving MiniMax configuration (API key + base URL)
- [ ] Test loading saved MiniMax configuration
- [ ] Verify MiniMax env vars are injected into sandboxes
- [ ] Confirm Anthropic configuration is unaffected
- [ ] Run `vitest run` to execute unit and integration tests