### PR TITLE
feat(skills): add MiniMax-AI/cli as default skill tap

### DIFF
--- a/lib/skills/catalog.ts
+++ b/lib/skills/catalog.ts
@@ -18,6 +18,16 @@ const skillCatalog: SkillCatalogEntry[] = [
       'npx -y skills add https://github.com/anthropics/skills --skill frontend-design -y',
     uninstallCommand: 'npx -y skills remove frontend-design -y',
   },
+  {
+    skillId: 'mmx-cli',
+    name: 'MiniMax CLI',
+    description:
+      'Generate text, images, video, speech, and music via MiniMax AI platform.',
+    sourceUrl: 'https://github.com/MiniMax-AI/cli',
+    installCommand:
+      'npx -y skills add https://github.com/MiniMax-AI/cli --skill mmx-cli -y',
+    uninstallCommand: 'npx -y skills remove mmx-cli -y',
+  },
 ]
 
 export function getSkillCatalog(): SkillCatalogEntry[] {


### PR DESCRIPTION
## Summary

- Add \`MiniMax-AI/cli\` to \`lib/skills/catalog.ts\` so the mmx-cli skill is discoverable in the Fulling skill catalog
- Users can install via \`npx -y skills add https://github.com/MiniMax-AI/cli --skill mmx-cli -y\` — the SKILL.md is fetched directly from [MiniMax-AI/cli](https://github.com/MiniMax-AI/cli/blob/main/skill/SKILL.md)
- Skill updates are fully decoupled: MiniMax maintains the upstream SKILL.md, no changes needed in this project

**1 line(s) changed (10 insertions), 0 new files.**

## What is mmx-cli?

[mmx-cli](https://github.com/MiniMax-AI/cli) is a CLI tool for the MiniMax AI platform, providing:
- **Text generation** (MiniMax-M2.7 model)
- **Image generation** (image-01)
- **Video generation** (Hailuo-2.3)
- **Speech synthesis** (speech-2.8-hd, 300+ voices)
- **Music generation** (music-2.6, with lyrics, cover, and instrumental)
- **Web search**

The [SKILL.md](https://github.com/MiniMax-AI/cli/blob/main/skill/SKILL.md) follows the [agentskills.io](https://agentskills.io) standard and includes agent-specific flags (`--non-interactive`, `--quiet`, `--output json`).

## Test plan

- `getSkillCatalog()` returns the mmx-cli skill entry
- `findSkillCatalogEntry('mmx-cli')` resolves correctly
- Install command: `npx -y skills add https://github.com/MiniMax-AI/cli --skill mmx-cli -y` installs successfully in sandbox
- Ask agent "generate a jazz instrumental" — agent invokes `mmx music generate` via terminal