### PR TITLE
[codex] define platform directory boundaries

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -88,7 +88,84 @@
 - WorkspaceRun
 - WorkspaceArtifact
 
-## 9. 关键流程目录
+## 9. 代码目录边界
+
+### lib/
+
+- 全应用基础设施
+- 通用工具
+- 环境变量
+- 数据库入口
+- Auth 入口
+- Logger
+- JWT
+- Fetch client
+
+### lib/platform/
+
+- Fulling 平台核心
+- Control
+- Orchestrators
+- Executors
+- Persistence
+- Integrations
+- Workspace 业务对象
+- Runtime 编排
+- Knowledge 管理
+- Memory 管理
+- Skill 绑定
+- Script 绑定
+- Access 控制
+- Artifact 管理
+
+### lib/platform/control/
+
+- 用户意图入口
+- Command
+- Query
+- 输入校验
+- 业务规则判断
+- 持久状态写入
+- 后续任务入队
+
+不放：
+
+- Route handler
+- React / UI
+- 长时间任务执行
+- 外部 SDK 协议细节
+- Reconciliation loop
+
+### lib/platform/control/commands/
+
+- create-workspace
+- create-workspace-from-template
+- configure-workspace-mission
+- import-workspace-knowledge
+- bind-workspace-skill
+- add-workspace-script
+- initialize-workspace-runtime
+- create-workspace-share
+- archive-workspace
+
+### lib/platform/integrations/
+
+- 外部平台适配
+- 外部 SDK 封装
+- 外部协议通信
+- Provider-specific 逻辑
+
+### lib/platform/integrations/sealos/
+
+- auth
+- session
+- k8s
+- devbox
+- aiproxy
+- namespace
+- runtime adapter
+
+## 10. 关键流程目录
 
 - 创建 workspace
 - 从 template 创建 workspace
@@ -105,7 +182,7 @@
 - 更新 memory
 - 归档 workspace
 
-## 10. 权限目录
+## 11. 权限目录
 
 - Creator 权限
 - Recipient 权限
@@ -116,7 +193,7 @@
 - Knowledge 访问权限
 - Memory 修改权限
 
-## 11. Runtime 目录
+## 12. Runtime 目录
 
 - Runtime Provisioning
 - Runtime Status
@@ -127,7 +204,7 @@
 - Runtime Reset
 - Runtime Shutdown
 
-## 12. Artifact 目录
+## 13. Artifact 目录
 
 - Text Output
 - File Output
@@ -138,7 +215,7 @@
 - Runtime Log
 - Approval Record
 
-## 13. 非目标
+## 14. 非目标
 
 - Prompt marketplace
 - Generic chatbot builder
@@ -146,7 +223,7 @@
 - DevOps control panel
 - 通用资源管理面板
 
-## 14. MVP 切片
+## 15. MVP 切片
 
 - Creator 创建 workspace
 - Creator 配置 mission
@@ -157,7 +234,7 @@
 - Recipient 打开 workspace
 - Recipient 完成一次任务
 
-## 15. 后续待设计
+## 16. 后续待设计
 
 - Template marketplace
 - Billing


### PR DESCRIPTION
## Summary

- Add code directory boundaries to the v3 architecture outline.
- Define what belongs in lib/, lib/platform/, lib/platform/control/, and lib/platform/integrations/.
- Capture the intended Sealos integration boundary under lib/platform/integrations/sealos/.

## Validation

- git diff --check
