### PR TITLE
fix: allow zero-config Vercel deployment

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-auto-install-peers=true
-shamefully-hoist=true 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,6 @@ COPY . .
 # Learn more here: https://nextjs.org/telemetry
 # Uncomment the following line in case you want to disable telemetry during the build.
 ENV NEXT_TELEMETRY_DISABLED=1
-ENV SKIP_ENV_VALIDATION=1
 
 # Generate Prisma Client and compile the Next.js application.
 RUN npm run build

--- a/README.md
+++ b/README.md
@@ -22,9 +22,11 @@ ownership model.
 
 ## Requirements
 
-- Node.js 22.12 or later, including its bundled npm 10 or later
-- PostgreSQL
-- a GitHub OAuth App
+- Node.js 22, including its bundled npm 10 or later
+
+The public application does not require PostgreSQL or an OAuth provider. The
+legacy authenticated workspace additionally requires PostgreSQL and a GitHub
+OAuth App.
 
 Configure the GitHub OAuth callback as:
 
@@ -36,6 +38,13 @@ ${BETTER_AUTH_URL}/api/auth/callback/github
 
 ```bash
 npm ci
+npm run dev
+```
+
+This starts the public application with sign-in disabled. To exercise the legacy
+authenticated workspace instead:
+
+```bash
 cp .env.template .env.local
 # Fill in the database, Better Auth, and GitHub values.
 npm run prisma:migrate
@@ -81,3 +90,14 @@ Fulling database does not delete Kubernetes resources created by v2.
 
 Use [docs/github-oauth-verification.md](./docs/github-oauth-verification.md) to
 verify a real OAuth application before release.
+
+## Vercel Deployment
+
+Fulling can use Vercel's native Next.js deployment without a `vercel.json` file.
+The public application builds and starts without environment variables. The
+current GitHub sign-in, database-backed workspace, and kubeconfig flows remain
+disabled until their complete legacy configuration is present.
+
+Follow [docs/vercel-deployment.md](./docs/vercel-deployment.md) for the complete
+project setup, zero-configuration behavior, verification steps, and rollback
+procedure.

--- a/app/(auth)/login/_components/github-login-button.tsx
+++ b/app/(auth)/login/_components/github-login-button.tsx
@@ -6,11 +6,13 @@ import { Github, LoaderCircle } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { signIn } from '@/lib/auth-client'
 
-export function GitHubLoginButton() {
+export function GitHubLoginButton({ enabled }: { enabled: boolean }) {
   const [isPending, setIsPending] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   async function handleSignIn() {
+    if (!enabled) return
+
     setIsPending(true)
     setError(null)
     const result = await signIn.social({
@@ -26,10 +28,21 @@ export function GitHubLoginButton() {
 
   return (
     <div className="mt-8 border-t border-border pt-6">
-      <Button type="button" size="lg" className="w-full" disabled={isPending} onClick={handleSignIn}>
+      <Button
+        type="button"
+        size="lg"
+        className="w-full"
+        disabled={!enabled || isPending}
+        onClick={handleSignIn}
+      >
         {isPending ? <LoaderCircle className="animate-spin" /> : <Github />}
-        {isPending ? 'Connecting...' : 'Continue with GitHub'}
+        {isPending ? 'Connecting...' : enabled ? 'Continue with GitHub' : 'Sign-in unavailable'}
       </Button>
+      {!enabled ? (
+        <p className="mt-3 text-sm text-muted-foreground">
+          GitHub sign-in is not available in this deployment.
+        </p>
+      ) : null}
       {error ? <p role="alert" className="mt-3 text-sm text-destructive">{error}</p> : null}
     </div>
   )

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from 'next/navigation'
 
 import { FullingBrand } from '@/components/fulling-brand'
+import { isAuthConfigured } from '@/lib/auth'
 import { getSession } from '@/lib/auth/session'
 
 import { GitHubLoginButton } from './_components/github-login-button'
@@ -25,17 +26,19 @@ export default async function LoginPage({ searchParams }: LoginPageProps) {
             Workspace access
           </p>
           <h1 className="mt-3 text-xl font-semibold leading-[var(--leading-heading)]">
-            Sign in to your workspace
+            {isAuthConfigured ? 'Sign in to your workspace' : 'Workspace access is being rebuilt'}
           </h1>
           <p className="mt-2 text-sm leading-6 text-muted-foreground">
-            Use your GitHub account to continue to Fulling.
+            {isAuthConfigured
+              ? 'Use your GitHub account to continue to Fulling.'
+              : 'The public preview is available, but sign-in and workspace data are temporarily disabled.'}
           </p>
           {error === 'oauth' ? (
             <p role="alert" className="mt-5 text-sm text-destructive">
               GitHub sign-in could not be completed. Please try again.
             </p>
           ) : null}
-          <GitHubLoginButton />
+          <GitHubLoginButton enabled={isAuthConfigured} />
         </div>
       </section>
       <footer className="h-12 shrink-0 border-t border-border px-4 text-xs leading-[48px] text-muted-foreground sm:px-6">

--- a/app/api/auth/[...all]/route.test.ts
+++ b/app/api/auth/[...all]/route.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/auth', () => ({ auth: null }))
+
+import { GET, POST } from './route'
+
+describe('/api/auth/[...all]', () => {
+  it.each([
+    ['GET', GET],
+    ['POST', POST],
+  ])('returns an explicit unavailable response for %s without auth configuration', async (_method, handler) => {
+    const response = await handler()
+
+    expect(response.status).toBe(503)
+    await expect(response.json()).resolves.toEqual({
+      code: 'AUTH_UNAVAILABLE',
+      message: 'Authentication is not configured.',
+    })
+  })
+})

--- a/app/api/auth/[...all]/route.ts
+++ b/app/api/auth/[...all]/route.ts
@@ -2,4 +2,15 @@ import { toNextJsHandler } from 'better-auth/next-js'
 
 import { auth } from '@/lib/auth'
 
-export const { GET, POST } = toNextJsHandler(auth)
+export const runtime = 'nodejs'
+
+const unavailable = () =>
+  Response.json(
+    { code: 'AUTH_UNAVAILABLE', message: 'Authentication is not configured.' },
+    { status: 503 }
+  )
+
+const handlers = auth ? toNextJsHandler(auth) : null
+
+export const GET = handlers?.GET ?? unavailable
+export const POST = handlers?.POST ?? unavailable

--- a/app/api/kubeconfig/route.ts
+++ b/app/api/kubeconfig/route.ts
@@ -11,6 +11,8 @@ import {
 } from '@/lib/kubeconfig'
 import { logger } from '@/lib/logger'
 
+export const runtime = 'nodejs'
+
 const unauthorized = () =>
   NextResponse.json({ code: 'UNAUTHORIZED', message: 'Sign in to continue.' }, { status: 401 })
 

--- a/docs/vercel-deployment.md
+++ b/docs/vercel-deployment.md
@@ -1,0 +1,75 @@
+# Vercel Deployment
+
+Fulling's public application can be deployed to Vercel without configuring
+GitHub OAuth, Better Auth, or PostgreSQL. Those integrations are currently
+optional so they do not block preview and production builds while workspace
+access is being rebuilt.
+
+## Project settings
+
+Connect `FullAgent/fulling` to a Vercel project and keep these settings:
+
+- Framework preset: Next.js
+- Root directory: repository root
+- Install command: Vercel default (`npm install` from `package-lock.json`)
+- Build command: `npm run build`
+- Output directory: Vercel default
+- Node.js: 22.x, enforced by `package.json`
+- Production branch: `main`
+
+No `vercel.json` file or application environment variables are required for this
+deployment mode. Do not set `SKIP_ENV_VALIDATION`; absent optional integrations
+are handled by the application itself.
+
+`output: 'standalone'` remains enabled because the Docker image consumes it.
+Vercel uses its native Next.js output.
+
+## Zero-configuration behavior
+
+Without the legacy Auth and database variables:
+
+- `/` renders the public landing page.
+- `/login` renders an explicit sign-in unavailable state.
+- `/api/auth/*` returns `503 AUTH_UNAVAILABLE` instead of initializing Better
+  Auth with an unsafe default secret.
+- Protected workspace routes redirect to `/login`.
+- No Prisma query or Kubernetes credential operation is attempted for anonymous
+  requests.
+
+The legacy Auth path is enabled only when all five variables are present:
+
+- `DATABASE_URL`
+- `BETTER_AUTH_URL`
+- `BETTER_AUTH_SECRET`
+- `GITHUB_CLIENT_ID`
+- `GITHUB_CLIENT_SECRET`
+
+This compatibility path is not required for the current Vercel deployment and
+will be replaced with the next authentication design.
+
+## Deploy and verify
+
+With Git integration, push a feature branch to create a Preview deployment and
+merge the verified commit to `main` for Production.
+
+Verify the zero-configuration deployment:
+
+1. Confirm `/` returns a successful response and renders the landing page.
+2. Confirm `/login` returns a successful response and shows the unavailable
+   state without a Better Auth error.
+3. Confirm a request to `/api/auth/session` returns a structured 503 response.
+4. Inspect the build and Function logs and confirm there are no missing-secret,
+   Prisma connection, or Kubernetes connection errors.
+
+Inspect a deployment in the Vercel dashboard or with the CLI:
+
+```bash
+vercel inspect <deployment-url>
+vercel logs <deployment-url>
+```
+
+Roll back a bad production deployment with:
+
+```bash
+vercel rollback
+```

--- a/lib/auth/config.ts
+++ b/lib/auth/config.ts
@@ -5,22 +5,39 @@ import { nextCookies } from 'better-auth/next-js'
 import { prisma } from '@/lib/db'
 import { env } from '@/lib/env'
 
-export const auth = betterAuth({
-  baseURL: env.BETTER_AUTH_URL,
-  secret: env.BETTER_AUTH_SECRET,
-  database: prismaAdapter(prisma, {
-    provider: 'postgresql',
-  }),
-  session: {
-    cookieCache: {
-      enabled: false,
+function createAuth() {
+  const {
+    BETTER_AUTH_SECRET: secret,
+    BETTER_AUTH_URL: baseURL,
+    DATABASE_URL: databaseUrl,
+    GITHUB_CLIENT_ID: clientId,
+    GITHUB_CLIENT_SECRET: clientSecret,
+  } = env
+
+  if (!baseURL || !secret || !databaseUrl || !clientId || !clientSecret) {
+    return null
+  }
+
+  return betterAuth({
+    baseURL,
+    secret,
+    database: prismaAdapter(prisma, {
+      provider: 'postgresql',
+    }),
+    session: {
+      cookieCache: {
+        enabled: false,
+      },
     },
-  },
-  socialProviders: {
-    github: {
-      clientId: env.GITHUB_CLIENT_ID,
-      clientSecret: env.GITHUB_CLIENT_SECRET,
+    socialProviders: {
+      github: {
+        clientId,
+        clientSecret,
+      },
     },
-  },
-  plugins: [nextCookies()],
-})
+    plugins: [nextCookies()],
+  })
+}
+
+export const auth = createAuth()
+export const isAuthConfigured = auth !== null

--- a/lib/auth/index.ts
+++ b/lib/auth/index.ts
@@ -1,4 +1,4 @@
-export { auth } from './config'
+export { auth, isAuthConfigured } from './config'
 export type { AppSession } from './session'
 export {
   getSession,

--- a/lib/auth/session.test.ts
+++ b/lib/auth/session.test.ts
@@ -1,16 +1,22 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { getSessionMock, headersMock, redirectMock } = vi.hoisted(() => ({
-  getSessionMock: vi.fn(),
-  headersMock: vi.fn(),
-  redirectMock: vi.fn(),
-}))
+const { authState, getSessionMock, headersMock, redirectMock } = vi.hoisted(() => {
+  const getSessionMock = vi.fn()
+  return {
+    authState: {
+      current: { api: { getSession: getSessionMock } } as null | {
+        api: { getSession: typeof getSessionMock }
+      },
+    },
+    getSessionMock,
+    headersMock: vi.fn(),
+    redirectMock: vi.fn(),
+  }
+})
 
 vi.mock('./config', () => ({
-  auth: {
-    api: {
-      getSession: getSessionMock,
-    },
+  get auth() {
+    return authState.current
   },
 }))
 
@@ -63,6 +69,15 @@ const appSession = {
 describe('session helpers', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    authState.current = { api: { getSession: getSessionMock } }
+  })
+
+  it('returns null without reading request headers when auth is not configured', async () => {
+    authState.current = null
+
+    await expect(getSession()).resolves.toBeNull()
+    expect(headersMock).not.toHaveBeenCalled()
+    expect(getSessionMock).not.toHaveBeenCalled()
   })
 
   it('passes request headers and returns only application user fields', async () => {

--- a/lib/auth/session.ts
+++ b/lib/auth/session.ts
@@ -22,6 +22,10 @@ export class UnauthorizedError extends Error {
 }
 
 export async function getSession(): Promise<AppSession | null> {
+  if (!auth) {
+    return null
+  }
+
   const session = await auth.api.getSession({
     headers: await headers(),
   })

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -3,14 +3,14 @@ import { z } from 'zod'
 
 export const env = createEnv({
   server: {
-    DATABASE_URL: z.url(),
-    BETTER_AUTH_URL: z.url(),
-    BETTER_AUTH_SECRET: z.string().min(32),
-    GITHUB_CLIENT_ID: z.string().min(1),
-    GITHUB_CLIENT_SECRET: z.string().min(1),
+    DATABASE_URL: z.url().optional(),
+    BETTER_AUTH_URL: z.url().optional(),
+    BETTER_AUTH_SECRET: z.string().min(32).optional(),
+    GITHUB_CLIENT_ID: z.string().min(1).optional(),
+    GITHUB_CLIENT_SECRET: z.string().min(1).optional(),
     LOG_LEVEL: z.string().optional(),
   },
   client: {},
   experimental__runtimeEnv: {},
-  skipValidation: !!process.env.SKIP_ENV_VALIDATION,
+  emptyStringAsUndefined: true,
 })

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,8 @@ import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,
+  // The Docker image consumes the standalone output. Vercel still uses its
+  // native Next.js build output and does not require a vercel.json file.
   output: 'standalone',
   compress: true,
   allowedDevOrigins: ['127.0.0.1'],

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@types/react-dom": "19.2.3"
   },
   "engines": {
-    "node": ">=22.12.0",
+    "node": "22.x",
     "npm": ">=10"
   }
 }


### PR DESCRIPTION
## Summary

- allow the public Fulling app to build and run on Vercel without Auth or database environment variables
- degrade unavailable authentication to an explicit login state and structured 503 API response
- pin Vercel to Node.js 22 and document the zero-configuration deployment path
- remove stale pnpm npm configuration and the Docker environment-validation bypass

## Why

The current GitHub Auth path is broken and will be replaced. Requiring Better Auth, GitHub OAuth, and PostgreSQL values prevented the public application from deploying even though those capabilities are not needed for the current preview.

This PR addresses the zero-configuration deployment slice of #181. It does not claim completion of the issue's future authentication, persistence, or Kubernetes connectivity acceptance criteria.

## Behavior

- `/` returns the public landing page
- `/login` renders a sign-in unavailable state
- `/api/auth/*` returns `503 AUTH_UNAVAILABLE` without a complete legacy Auth configuration
- protected routes redirect to `/login`
- the legacy Auth path remains available only when all existing Auth and database variables are present

## Validation

- Node.js 22 production image built with no environment variables and without `SKIP_ENV_VALIDATION`
- runtime smoke test: `/` 200, `/login` 200, `/workspace` 307 to `/login`, `/api/auth/session` 503
- `npm run lint`
- `npm test` (38 tests)
