### PR TITLE
refactor: reuse FullingBrand in landing header

### DIFF
--- a/app/(landing)/_components/landing-client.tsx
+++ b/app/(landing)/_components/landing-client.tsx
@@ -1,7 +1,8 @@
 import { FaLinkedinIn } from 'react-icons/fa6'
 import { SiDiscord, SiGithub, SiX, SiYoutube } from 'react-icons/si'
-import Image from 'next/image'
 import Link from 'next/link'
+
+import { FullingBrand } from '@/components/fulling-brand'
 
 import styles from './landing.module.css'
 
@@ -15,12 +16,7 @@ export function LandingClient({ ctaHref, githubStars }: LandingClientProps) {
     <div className={styles.page}>
       <header className={styles.header}>
         <div className={styles.headerInner}>
-          <Link href="/" className={styles.brand} aria-label="Fulling home">
-            <span className={styles.brandMark} aria-hidden="true">
-              <Image src="/icon-transparent.svg" alt="" width={40} height={40} priority />
-            </span>
-            <span>Fulling</span>
-          </Link>
+          <FullingBrand />
 
           <nav className={styles.headerNav} aria-label="Primary navigation">
             <button type="button" disabled className={styles.blogLink} aria-label="Blog, coming soon">

--- a/app/(landing)/_components/landing.module.css
+++ b/app/(landing)/_components/landing.module.css
@@ -26,35 +26,6 @@
   gap: 24px;
 }
 
-.brand {
-  display: inline-flex;
-  align-items: center;
-  width: max-content;
-  gap: 8px;
-  color: var(--color-fulling-ink);
-  font-size: 22px;
-  font-weight: 600;
-  line-height: 24px;
-  letter-spacing: -0.5px;
-}
-
-.brandMark {
-  position: relative;
-  width: 24px;
-  height: 24px;
-  overflow: hidden;
-}
-
-.brandMark img {
-  position: absolute;
-  top: -8px;
-  left: -8px;
-  width: 40px;
-  height: 40px;
-  max-width: none;
-  filter: brightness(0);
-}
-
 .headerNav {
   display: flex;
   align-items: center;
@@ -315,7 +286,6 @@
   height: 14px;
 }
 
-.brand:focus-visible,
 .starLink:focus-visible,
 .dashboardLink:focus-visible,
 .previewLink:focus-visible,
@@ -333,10 +303,6 @@
 
   .headerInner {
     height: 31px;
-  }
-
-  .brand {
-    font-size: 20px;
   }
 
   .headerNav {

--- a/components/fulling-brand.test.tsx
+++ b/components/fulling-brand.test.tsx
@@ -1,0 +1,27 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+
+import { FullingBrand } from './fulling-brand'
+
+describe('FullingBrand', () => {
+  it('renders the canonical brand lockup and accessible home link', () => {
+    const markup = renderToStaticMarkup(<FullingBrand />)
+
+    expect(markup).toContain('href="/"')
+    expect(markup).toContain('aria-label="Fulling home"')
+    expect(markup).toContain('text-[22px]')
+    expect(markup).toContain('leading-6')
+    expect(markup).toContain('tracking-[-0.5px]')
+    expect(markup).toContain('size-6')
+    expect(markup).toContain('>Fulling</span>')
+  })
+
+  it('supports a surface-specific destination and layout class', () => {
+    const markup = renderToStaticMarkup(
+      <FullingBrand href="/workspace" className="shrink-0" />,
+    )
+
+    expect(markup).toContain('href="/workspace"')
+    expect(markup).toContain('shrink-0')
+  })
+})

--- a/components/fulling-brand.tsx
+++ b/components/fulling-brand.tsx
@@ -13,7 +13,7 @@ export function FullingBrand({ className, href = '/' }: FullingBrandProps) {
     <Link
       href={href}
       className={cn(
-        'inline-flex w-max items-center gap-2 text-xl font-semibold leading-none text-foreground',
+        'inline-flex w-max items-center gap-2 text-[22px] font-semibold leading-6 tracking-[-0.5px] text-foreground',
         className,
       )}
       aria-label="Fulling home"


### PR DESCRIPTION
## Summary

- reuse the shared `FullingBrand` component in the landing header
- make the landing wordmark typography (`22px` size, `24px` line height, and `-0.5px` tracking) canonical across landing, login, and dashboard headers
- remove the duplicated landing brand markup and obsolete responsive styles
- add regression coverage for canonical rendering, accessibility, and surface-specific destinations

## Why

The landing page duplicated the shared brand lockup introduced for login and dashboard. That component-boundary omission allowed the wordmark typography and responsive behavior to drift between surfaces. Centralizing the lockup keeps brand dimensions and accessible labeling consistent.

## Impact

Landing, login, and dashboard now render the same brand treatment. Dashboard retains its `/workspace` destination; landing and login continue to link to `/`.

## Validation

- `npm test` — 40 tests passed
- `npm run lint`
- `npm run build`
- `git diff --check`

Fixes #188
